### PR TITLE
Vagrantfile: switch back to vboxsf

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -49,7 +49,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Then, do stack-specific and app-specific setup.
   config.vm.provision "shell", inline: "sudo bash /opt/app/.sandstorm/setup.sh"
 
-  # Shared folders are configured per-provider, since vboxsf can't handle >4096 open files,
+  # Shared folders are configured per-provider since vboxsf can't handle >4096 open files,
   # NFS requires privilege escalation every time you bring a VM up,
   # and 9p is only available on libvirt.
 
@@ -87,12 +87,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb, override|
     vb.cpus = cpus
     vb.memory = assign_ram_mb
-    # exportfs complains if you try to export the same folder twice.
-    # Vagrant isn't currently smart enough to dedupe paths.
-    # We don't use /vagrant anyway, so leave it out.
-    # TODO: Windows support
-    override.vm.synced_folder "..", "/opt/app", type: "nfs"
+
+    override.vm.synced_folder "..", "/opt/app"
     override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm"
+    override.vm.synced_folder "..", "/vagrant"
   end
   config.vm.provider :libvirt do |libvirt, override|
     libvirt.cpus = cpus
@@ -101,6 +99,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     override.vm.synced_folder "..", "/opt/app", type: "9p", accessmode: "passthrough"
     override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm", type: "9p", accessmode: "passthrough"
+    override.vm.synced_folder "..", "/vagrant", type: "9p", accessmode: "passthrough"
   end
 end
 """


### PR DESCRIPTION
This PR is blocked on https://github.com/sandstorm-io/sandstorm/pull/494 making it into a sandstorm binary release; don't merge until that one is released.

-----

A PR for spk prevents us from hitting the 4096-file-handle limit:
https://github.com/sandstorm-io/sandstorm/pull/494

So we can switch back to the default shared folder mechanism, which
has a couple of nice benefits:

1. Works on Windows at all
2. OSX users don't have to enter sudo password every time they start or stop
   the VM
3. Can map /vagrant to the same folder as /opt/app

Libvirt still does better with an explicit p9fs, which is bidirectional, as
opposed to the default synced_folder backend, which is rsync and only syncs
from host to guest.