### PR TITLE
Reduce MySQL disk usage

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -198,6 +198,14 @@ sed --in-place='' \
 sed --in-place='' \
         --expression='s/^user\t\t= mysql/#user\t\t= mysql/' \
         /etc/mysql/my.cnf
+# patch mysql conf to use smaller transaction logs to save disk space
+cat <<EOF > /etc/mysql/conf.d/sandstorm.cnf
+[mysqld]
+# Set the transaction log file to the minimum allowed size to save disk space.
+innodb_log_file_size = 1048576
+# Set the main data file to grow by 1MB at a time, rather than 8MB at a time.
+innodb_autoextend_increment = 1
+EOF
 # patch nginx conf to not bother trying to setuid, since we're not root
 sed --in-place='' \
         --expression 's/^user www-data/#user www-data/' \
@@ -293,6 +301,14 @@ ln -s /etc/nginx/sites-available/sandstorm-python /etc/nginx/sites-enabled/sands
 sed --in-place='' \
         --expression='s/^user\t\t= mysql/#user\t\t= mysql/' \
         /etc/mysql/my.cnf
+# patch mysql conf to use smaller transaction logs to save disk space
+[mysqld]
+cat <<EOF > /etc/mysql/conf.d/sandstorm.cnf
+# Set the transaction log file to the minimum allowed size to save disk space.
+innodb_log_file_size = 1048576
+# Set the main data file to grow by 1MB at a time, rather than 8MB at a time.
+innodb_autoextend_increment = 1
+EOF
 # patch nginx conf to not bother trying to setuid, since we're not root
 sed --in-place='' \
         --expression 's/^user www-data/#user www-data/' \


### PR DESCRIPTION
This brings disk usage down to ~15MB.  I don't think we'll be able to do much
better; InnoDB requires at least 10MB for its data file path, so short of using
a patched mysqld, we can't fix this.

We could consider maintaining a patched MySQL which gets automatically pulled
in for vagrant-spk users, if that seems like a worthwhile time investment.

Worth noting: this is likely *not* a safe thing to push to existing packages with MySQL DBs.
https://dev.mysql.com/doc/refman/5.5/en/innodb-data-log-reconfiguration.html
suggests that you'd have to tell the server to completely flush the log, then
manually delete the logfiles before changing their size in the config.