### PR TITLE
Use $PATH to find python2.7

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 #   Copyright 2015 Drew Fisher (zarvox@zarvox.org)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is theoretically safer than hard-coding `/usr/bin/python2.7`.

Hat-tip to @alex for suggesting this.