### PR TITLE
Fix command-not-found issue in setup.sh for Python stack

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -302,8 +302,8 @@ sed --in-place='' \
         --expression='s/^user\t\t= mysql/#user\t\t= mysql/' \
         /etc/mysql/my.cnf
 # patch mysql conf to use smaller transaction logs to save disk space
-[mysqld]
 cat <<EOF > /etc/mysql/conf.d/sandstorm.cnf
+[mysqld]
 # Set the transaction log file to the minimum allowed size to save disk space.
 innodb_log_file_size = 1048576
 # Set the main data file to grow by 1MB at a time, rather than 8MB at a time.


### PR DESCRIPTION
This commit fixes an issue where the [mysqld] string is placed
before the heredoc that uses it.

Thanks to Jack Singleton for finding it.