### PR TITLE
Purge logfiles in grain packages

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -263,6 +263,13 @@ rm -rf /var/run
 mkdir -p /var/run
 mkdir -p /var/run/mysqld
 
+# Cleanup log files
+FILES="$(find /var/log -name '*.log')"
+for f in $FILES
+do
+  tail $f | tee $f
+done
+
 # Ensure mysql tables created
 HOME=/etc/mysql /usr/bin/mysql_install_db --force
 


### PR DESCRIPTION
See https://github.com/sandstorm-io/vagrant-spk/issues/42

This removes all content of all ```*.log``` files in ```/var/log``` and only keeps the last 10 lines. This should prevent having big sized log files in grains which grow and grow..