### PR TITLE
Headless, full-auto, DRY win32 package building

### DIFF
--- a/windows-support/Makefile
+++ b/windows-support/Makefile
@@ -1,7 +1,7 @@
 all: dist/innosetup/vagrant-spk-setup.exe
 
-WINE:=wine
-WINEARGS:=WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix
+WINE := wine
+WINEARGS := WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix
 
 clean:
 	rm -f dist/innosetup/vagrant-spk-setup.exe

--- a/windows-support/Makefile
+++ b/windows-support/Makefile
@@ -37,7 +37,7 @@ vendor/pywin32.exe.installed: | vendor/pywin32.exe
 	unzip vendor/pywin32.exe || true
 	mv PLATLIB/* SCRIPTS/* state/wineprefix/drive_c/Python27/Lib/site-packages/
 	rmdir PLATLIB SCRIPTS
-	$(WINEARGS) $(WINE) python state/wineprefix/drive_c/Python27/Lib/site-packages/pywin32_postinstall.py -install
+	$(WINEARGS) $(WINE) 'c:/python27/python.exe' state/wineprefix/drive_c/Python27/Lib/site-packages/pywin32_postinstall.py -install
 	touch vendor/pywin32.exe.installed
 
 dist/vagrant-spk.exe: ../vagrant-spk | state/wineprefix/drive_c/Python27/Scripts/pyinstaller.exe

--- a/windows-support/Makefile
+++ b/windows-support/Makefile
@@ -1,5 +1,8 @@
 all: dist/innosetup/vagrant-spk-setup.exe
 
+WINE:=wine
+WINEARGS:=WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix
+
 clean:
 	rm -f dist/innosetup/vagrant-spk-setup.exe
 
@@ -12,37 +15,45 @@ wine: /usr/bin/wine
 vendor:
 	mkdir -p vendor
 
+state:
+	mkdir -p state
+
 vendor/python.msi: | vendor state/wineprefix
 	wget https://www.python.org/ftp/python/2.7.10/python-2.7.10.msi -O vendor/python.msi
 	touch vendor/python.msi
 
 vendor/python.msi.installed: | vendor/python.msi
 	cp vendor/python.msi vendor/python-tmp.msi
-	WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix WINEARCH=win32 wine msiexec /i vendor/python-tmp.msi
+	$(WINEARGS) $(WINE) msiexec /i vendor/python-tmp.msi /qn
 	touch vendor/python.msi.installed
 
 state/wineprefix/drive_c/Python27/Scripts/pyinstaller.exe: | vendor/python.msi.installed vendor/pywin32.exe.installed
-	WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix WINEARCH=win32 wine 'c:/python27/python.exe' -m pip install pyinstaller
+	$(WINEARGS) $(WINE) 'c:/python27/python.exe' -m pip install pyinstaller
 
 vendor/pywin32.exe: | vendor
 	wget http://iweb.dl.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py2.7.exe -O vendor/pywin32.exe
 
 vendor/pywin32.exe.installed: | vendor/pywin32.exe
-	WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix WINEARCH=win32 wine vendor/pywin32.exe
+	unzip vendor/pywin32.exe || true
+	mv PLATLIB/* SCRIPTS/* state/wineprefix/drive_c/Python27/Lib/site-packages/
+	rmdir PLATLIB SCRIPTS
+	$(WINEARGS) $(WINE) python state/wineprefix/drive_c/Python27/Lib/site-packages/pywin32_postinstall.py -install
 	touch vendor/pywin32.exe.installed
 
 dist/vagrant-spk.exe: ../vagrant-spk | state/wineprefix/drive_c/Python27/Scripts/pyinstaller.exe
-	WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix WINEARCH=win32 wine c:/python27/Scripts/pyinstaller -F ../vagrant-spk
+	$(WINEARGS) $(WINE) c:/python27/Scripts/pyinstaller -F ../vagrant-spk
 
 vendor/innosetup.exe: | vendor
 	wget 'http://www.jrsoftware.org/download.php/is.exe?site=1' -O vendor/innosetup.exe
 
 vendor/innosetup.exe.installed: | state/wineprefix vendor/innosetup.exe
-	WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix WINEARCH=win32 wine vendor/innosetup.exe
+	$(WINEARGS) $(WINE) vendor/innosetup.exe /VERYSILENT
 	touch vendor/innosetup.exe.installed
 
 dist/innosetup/vagrant-spk-setup.exe: dist/vagrant-spk.exe | vendor/innosetup.exe.installed vendor/msysgit.7z vendor/msysgit/bin
-	WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix WINEARCH=win32 wine 'c:/program files/inno setup 5/iscc.exe' windows-installer.iss
+	# It's possible we need to make this (x86) conditional on the 64-bitness of your wine install.
+	# For now, assume people have 64-bit wine and carry on.
+	$(WINEARGS) $(WINE) 'c:/program files (x86)/inno setup 5/iscc.exe' windows-installer.iss
 
 vendor/msysgit.7z:
 	wget https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20150319/PortableGit-1.9.5-preview20150319.7z -O vendor/msysgit.7z
@@ -51,11 +62,11 @@ vendor/msysgit/bin:
 	mkdir -p vendor/msysgit
 	(cd vendor/msysgit ; 7z e -aoa ../msysgit.7z)
 
-state/regdata:
+state/regdata: | state
 	printf '[HKEY_CURRENT_USER\\Software\\Wine\\WineDbg]\n"ShowCrashDialog"=dword:00000000\n' > state/regdata
 
 state/wineprefix: state/regdata
 	mkdir -p state/wineprefix
-	WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix WINEARCH=win32 wine wineboot
-	WINEDEBUG=-all WINEPREFIX=$$PWD/state/wineprefix WINEARCH=win32 wine regedit state/regdata
+	$(WINEARGS) $(WINE) wineboot
+	$(WINEARGS) $(WINE) regedit state/regdata
 	touch state/wineprefix

--- a/windows-support/Makefile
+++ b/windows-support/Makefile
@@ -51,8 +51,9 @@ vendor/innosetup.exe.installed: | state/wineprefix vendor/innosetup.exe
 	touch vendor/innosetup.exe.installed
 
 dist/innosetup/vagrant-spk-setup.exe: dist/vagrant-spk.exe | vendor/innosetup.exe.installed vendor/msysgit.7z vendor/msysgit/bin
-	# It's possible we need to make this (x86) conditional on the 64-bitness of your wine install.
-	# For now, assume people have 64-bit wine and carry on.
+	# Some WINE installs are seemingly 64-bit but install InnoSetup to Program Files, not
+	# Program Files (x86). We work around this with a symlink.
+	if [ ! -d 'state/wineprefix/drive_c/Program Files (x86)' ] ; then ln -s 'Program Files' 'state/wineprefix/drive_c/Program Files (x86)' ; fi
 	$(WINEARGS) $(WINE) 'c:/program files (x86)/inno setup 5/iscc.exe' windows-installer.iss
 
 vendor/msysgit.7z:


### PR DESCRIPTION
Now you can theoretically just run "make" and get the packaged exe, rather than having to click through some setup wizards.

@paulproteus review and merge?