### PR TITLE
Windows: detect and use appropriate CPUs/RAM like OSX/Linux

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -76,6 +76,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   elsif host =~ /linux/
     cpus = `nproc`.to_i
     total_kB_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
+  elsif host =~ /mingw/
+    # powershell may not be available on Windows XP and Vista, so wrap this in a rescue block
+    begin
+      cpus = `powershell -Command "(Get-WmiObject Win32_Processor -Property NumberOfLogicalProcessors | Select-Object -Property NumberOfLogicalProcessors | Measure-Object NumberOfLogicalProcessors -Sum).Sum"`.to_i
+      total_kB_ram = `powershell -Command "Get-CimInstance -class cim_physicalmemory | % $_.Capacity}"`.to_i / 1024
+    rescue
+    end
   end
   # Use the same number of CPUs within Vagrant as the system, with 1
   # as a default.
@@ -86,7 +93,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # RAM entirely (which it basically would if we went much lower than
   # 512MB) and also allowing it to use up a healthily large amount of
   # RAM so it can run faster on systems that can afford it.
-  if cpus.nil?
+  if cpus.nil? or cpus.zero?
     cpus = 1
   end
   if total_kB_ram.nil? or total_kB_ram < 2048000


### PR DESCRIPTION
This should improve the experience on Win7 and higher hosts, which will now
assign all the host CPUs and a quarter of the host's RAM (or 512MB, whichever
is larger) to the VM.