### PR TITLE
nginx: by default, don't limit max body size

### DIFF
--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -11,6 +11,11 @@ server {
     listen 8000 default_server;
     listen [::]:8000 default_server ipv6only=on;
 
+    # Allow arbitrarily large bodies - Sandstorm can handle them, and requests
+    # are authenticated already, so there's no reason for apps to add additional
+    # limits by default.
+    client_max_body_size 0;
+
     server_name localhost;
     root /opt/app;
     location / {

--- a/stacks/static/setup.sh
+++ b/stacks/static/setup.sh
@@ -11,6 +11,11 @@ server {
     listen 8000 default_server;
     listen [::]:8000 default_server ipv6only=on;
 
+    # Allow arbitrarily large bodies - Sandstorm can handle them, and requests
+    # are authenticated already, so there's no reason for apps to add additional
+    # limits by default.
+    client_max_body_size 0;
+
     server_name localhost;
     root /opt/app;
 }

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -11,6 +11,11 @@ server {
     listen 8000 default_server;
     listen [::]:8000 default_server ipv6only=on;
 
+    # Allow arbitrarily large bodies - Sandstorm can handle them, and requests
+    # are authenticated already, so there's no reason for apps to add additional
+    # limits by default.
+    client_max_body_size 0;
+
     server_name localhost;
     root /opt/app;
     location /static/ {


### PR DESCRIPTION
nginx will limit this to 1MB by default, which is pretty small for a lot of
apps that allow e.g. photo or media uploads.