### PR TITLE
lemp: pass environment variables on to php-fpm

### DIFF
--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -49,6 +49,11 @@ sed --in-place='' \
 sed --in-place='' \
         --expression='s/^pid =/#pid =/' \
         /etc/php5/fpm/php-fpm.conf
+# patch /etc/php5/fpm/pool.d/www.conf to no clear environment variables
+# so we can pass in SANDSTORM=1 to apps
+sed --in-place='' \
+        --expression='s/^;clear_env = no/clear_env=no/' \
+        /etc/php5/fpm/pool.d/www.conf
 # patch mysql conf to not change uid
 sed --in-place='' \
         --expression='s/^user\t\t= mysql/#user\t\t= mysql/' \


### PR DESCRIPTION
This allows us to set SANDSTORM=1 in the default environment block generated by
`spk init` and then call getenv("SANDSTORM") in PHP apps to see if they're
being run under Sandstorm or not.