### PR TITLE
Need to restart so the new BIND_IP takes effect.

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -152,6 +152,7 @@ usermod -a -G 'sandstorm' 'vagrant'
 sudo sed --in-place='' \
         --expression='s/^BIND_IP=.*/BIND_IP=0.0.0.0/' \
         /opt/sandstorm/sandstorm.conf
+sudo service sandstorm restart
 # Enable apt-cacher-ng proxy to make things faster if one appears to be running on the gateway IP
 GATEWAY_IP=$(ip route  | grep ^default  | cut -d ' ' -f 3)
 if nc -z "$GATEWAY_IP" 3142 ; then


### PR DESCRIPTION
After #77, on an initial `vagrant-spk up` Sandstorm does not become available on local.sandstorm.io:6080. This patch fixes the problem.