### PR TITLE
Add node stack

### DIFF
--- a/stacks/node/build.sh
+++ b/stacks/node/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+# This script is run in the VM each time you run `vagrant-spk dev`.  This is
+# the ideal place to invoke anything which is normally part of your app's build
+# process - transforming the code in your repository into the collection of files
+# which can actually run the service in production
+#
+# Some examples:
+#
+#   * For a C/C++ application, calling
+#       ./configure && make && make install
+#   * For a Python application, creating a virtualenv and installing
+#     app-specific package dependencies:
+#       virtualenv /opt/app/env
+#       /opt/app/env/bin/pip install -r /opt/app/requirements.txt
+#   * Building static assets from .less or .sass, or bundle and minify JS
+#   * Collecting various build artifacts or assets into a deployment-ready
+#     directory structure
+
+# By default, this script does nothing.  You'll have to modify it as
+# appropriate for your application.
+cd /opt/app
+
+npm install
+
+# bower install

--- a/stacks/node/launcher.sh
+++ b/stacks/node/launcher.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+# This script is run every time an instance of our app - aka grain - starts up.
+# This is the entry point for your application both when a grain is first launched
+# and when a grain resumes after being previously shut down.
+#
+# This script is responsible for launching everything your app needs to run.  The
+# thing it should do *last* is:
+#
+#   * Start a process in the foreground listening on port 8000 for HTTP requests.
+#
+# This is how you indicate to the platform that your application is up and
+# ready to receive requests.  Often, this will be something like nginx serving
+# static files and reverse proxying for some other dynamic backend service.
+#
+# Other things you probably want to do in this script include:
+#
+#   * Building folder structures in /var.  /var is the only non-tmpfs folder
+#     mounted read-write in the sandbox, and when a grain is first launched, it
+#     will start out empty.  It will persist between runs of the same grain, but
+#     be unique per app instance.  That is, two instances of the same app have
+#     separate instances of /var.
+#   * Preparing a database and running migrations.  As your package changes
+#     over time and you release updates, you will need to deal with migrating
+#     data from previous schema versions to new ones, since users should not have
+#     to think about such things.
+#   * Launching other daemons your app needs (e.g. mysqld, redis-server, etc.)
+
+# By default, this script does nothing.  You'll have to modify it as
+# appropriate for your application.
+cd /opt/app
+
+npm start

--- a/stacks/node/launcher.sh
+++ b/stacks/node/launcher.sh
@@ -30,4 +30,7 @@ set -euo pipefail
 # appropriate for your application.
 cd /opt/app
 
+# express.js has fewer problems when HOME is defined
+export HOME=/opt/app
+
 npm start

--- a/stacks/node/setup.sh
+++ b/stacks/node/setup.sh
@@ -4,26 +4,84 @@ set -euo pipefail
 # useful for installing system-global dependencies.  It is run exactly once
 # over the lifetime of the VM.
 #
-# This is the ideal place to do things like:
-#
-#    export DEBIAN_FRONTEND=noninteractive
-#    apt-get install -y nginx nodejs nodejs-legacy python2.7 mysql-server
-#
-# If the packages you're installing here need some configuration adjustments,
-# this is also a good place to do that:
-#
-#    sed --in-place='' \
-#            --expression 's/^user www-data/#user www-data/' \
-#            --expression 's#^pid /run/nginx.pid#pid /var/run/nginx.pid#' \
-#            --expression 's/^\s*error_log.*/error_log stderr;/' \
-#            --expression 's/^\s*access_log.*/access_log off;/' \
-#            /etc/nginx/nginx.conf
 
-# By default, this script does nothing.  You'll have to modify it as
-# appropriate for your application.
+# Install node.js
+
+# Discussion, issues and change requests at:
+#   https://github.com/nodesource/distributions
+#
+# Script to install the NodeSource Node.js 4.x repo onto a
+# Debian or Ubuntu system.
 
 export DEBIAN_FRONTEND=noninteractive
-curl -sL https://deb.nodesource.com/setup_4.x | bash -
-apt-get install -y nodejs git-core g++
+
+echo "Installing the NodeSource Node.js 4.x repo..."
+
+apt-get update
+apt-get install -qq apt-transport-https
+
+echo 'deb https://deb.nodesource.com/node_4.x jessie main' > /etc/apt/sources.list.d/nodesource.list
+echo 'deb-src https://deb.nodesource.com/node_4.x jessie main' >> /etc/apt/sources.list.d/nodesource.list
+
+# Add nodesource's apt gpg key inline
+echo "
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1
+Comment: GPGTools - https://gpgtools.org
+
+mQINBFObJLYBEADkFW8HMjsoYRJQ4nCYC/6Eh0yLWHWfCh+/9ZSIj4w/pOe2V6V+
+W6DHY3kK3a+2bxrax9EqKe7uxkSKf95gfns+I9+R+RJfRpb1qvljURr54y35IZgs
+fMG22Np+TmM2RLgdFCZa18h0+RbH9i0b+ZrB9XPZmLb/h9ou7SowGqQ3wwOtT3Vy
+qmif0A2GCcjFTqWW6TXaY8eZJ9BCEqW3k/0Cjw7K/mSy/utxYiUIvZNKgaG/P8U7
+89QyvxeRxAf93YFAVzMXhoKxu12IuH4VnSwAfb8gQyxKRyiGOUwk0YoBPpqRnMmD
+Dl7SdmY3oQHEJzBelTMjTM8AjbB9mWoPBX5G8t4u47/FZ6PgdfmRg9hsKXhkLJc7
+C1btblOHNgDx19fzASWX+xOjZiKpP6MkEEzq1bilUFul6RDtxkTWsTa5TGixgCB/
+G2fK8I9JL/yQhDc6OGY9mjPOxMb5PgUlT8ox3v8wt25erWj9z30QoEBwfSg4tzLc
+Jq6N/iepQemNfo6Is+TG+JzI6vhXjlsBm/Xmz0ZiFPPObAH/vGCY5I6886vXQ7ft
+qWHYHT8jz/R4tigMGC+tvZ/kcmYBsLCCI5uSEP6JJRQQhHrCvOX0UaytItfsQfLm
+EYRd2F72o1yGh3yvWWfDIBXRmaBuIGXGpajC0JyBGSOWb9UxMNZY/2LJEwARAQAB
+tB9Ob2RlU291cmNlIDxncGdAbm9kZXNvdXJjZS5jb20+iQI4BBMBAgAiBQJTmyS2
+AhsDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRAWVaCraFdigHTmD/9OKhUy
+jJ+h8gMRg6ri5EQxOExccSRU0i7UHktecSs0DVC4lZG9AOzBe+Q36cym5Z1di6JQ
+kHl69q3zBdV3KTW+H1pdmnZlebYGz8paG9iQ/wS9gpnSeEyx0Enyi167Bzm0O4A1
+GK0prkLnz/yROHHEfHjsTgMvFwAnf9uaxwWgE1d1RitIWgJpAnp1DZ5O0uVlsPPm
+XAhuBJ32mU8S5BezPTuJJICwBlLYECGb1Y65Cil4OALU7T7sbUqfLCuaRKxuPtcU
+VnJ6/qiyPygvKZWhV6Od0Yxlyed1kftMJyYoL8kPHfeHJ+vIyt0s7cropfiwXoka
+1iJB5nKyt/eqMnPQ9aRpqkm9ABS/r7AauMA/9RALudQRHBdWIzfIg0Mlqb52yyTI
+IgQJHNGNX1T3z1XgZhI+Vi8SLFFSh8x9FeUZC6YJu0VXXj5iz+eZmk/nYjUt4Mtc
+pVsVYIB7oIDIbImODm8ggsgrIzqxOzQVP1zsCGek5U6QFc9GYrQ+Wv3/fG8hfkDn
+xXLww0OGaEQxfodm8cLFZ5b8JaG3+Yxfe7JkNclwvRimvlAjqIiW5OK0vvfHco+Y
+gANhQrlMnTx//IdZssaxvYytSHpPZTYw+qPEjbBJOLpoLrz8ZafN1uekpAqQjffI
+AOqW9SdIzq/kSHgl0bzWbPJPw86XzzftewjKNbkCDQRTmyS2ARAAxSSdQi+WpPQZ
+fOflkx9sYJa0cWzLl2w++FQnZ1Pn5F09D/kPMNh4qOsyvXWlekaV/SseDZtVziHJ
+Km6V8TBG3flmFlC3DWQfNNFwn5+pWSB8WHG4bTA5RyYEEYfpbekMtdoWW/Ro8Kmh
+41nuxZDSuBJhDeFIp0ccnN2Lp1o6XfIeDYPegyEPSSZqrudfqLrSZhStDlJgXjea
+JjW6UP6txPtYaaila9/Hn6vF87AQ5bR2dEWB/xRJzgNwRiax7KSU0xca6xAuf+TD
+xCjZ5pp2JwdCjquXLTmUnbIZ9LGV54UZ/MeiG8yVu6pxbiGnXo4Ekbk6xgi1ewLi
+vGmz4QRfVklV0dba3Zj0fRozfZ22qUHxCfDM7ad0eBXMFmHiN8hg3IUHTO+UdlX/
+aH3gADFAvSVDv0v8t6dGc6XE9Dr7mGEFnQMHO4zhM1HaS2Nh0TiL2tFLttLbfG5o
+QlxCfXX9/nasj3K9qnlEg9G3+4T7lpdPmZRRe1O8cHCI5imVg6cLIiBLPO16e0fK
+yHIgYswLdrJFfaHNYM/SWJxHpX795zn+iCwyvZSlLfH9mlegOeVmj9cyhN/VOmS3
+QRhlYXoA2z7WZTNoC6iAIlyIpMTcZr+ntaGVtFOLS6fwdBqDXjmSQu66mDKwU5Ek
+fNlbyrpzZMyFCDWEYo4AIR/18aGZBYUAEQEAAYkCHwQYAQIACQUCU5sktgIbDAAK
+CRAWVaCraFdigIPQEACcYh8rR19wMZZ/hgYv5so6Y1HcJNARuzmffQKozS/rxqec
+0xM3wceL1AIMuGhlXFeGd0wRv/RVzeZjnTGwhN1DnCDy1I66hUTgehONsfVanuP1
+PZKoL38EAxsMzdYgkYH6T9a4wJH/IPt+uuFTFFy3o8TKMvKaJk98+Jsp2X/QuNxh
+qpcIGaVbtQ1bn7m+k5Qe/fz+bFuUeXPivafLLlGc6KbdgMvSW9EVMO7yBy/2JE15
+ZJgl7lXKLQ31VQPAHT3an5IV2C/ie12eEqZWlnCiHV/wT+zhOkSpWdrheWfBT+ac
+hR4jDH80AS3F8jo3byQATJb3RoCYUCVc3u1ouhNZa5yLgYZ/iZkpk5gKjxHPudFb
+DdWjbGflN9k17VCf4Z9yAb9QMqHzHwIGXrb7ryFcuROMCLLVUp07PrTrRxnO9A/4
+xxECi0l/BzNxeU1gK88hEaNjIfviPR/h6Gq6KOcNKZ8rVFdwFpjbvwHMQBWhrqfu
+G3KaePvbnObKHXpfIKoAM7X2qfO+IFnLGTPyhFTcrl6vZBTMZTfZiC1XDQLuGUnd
+sckuXINIU3DFWzZGr0QrqkuE/jyr7FXeUJj9B7cLo+s/TXo+RaVfi3kOc9BoxIvy
+/qiNGs/TKy2/Ujqp/affmIMoMXSozKmga81JSwkADO1JMgUy6dApXz9kP4EE3g==
+=CLGF
+-----END PGP PUBLIC KEY BLOCK-----
+" | apt-key add -
+
+apt-get update
+
+# Actually install node
+apt-get install -qq nodejs git-core g++
 
 exit 0

--- a/stacks/node/setup.sh
+++ b/stacks/node/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+# This script is run in the VM once when you first run `vagrant-spk up`.  It is
+# useful for installing system-global dependencies.  It is run exactly once
+# over the lifetime of the VM.
+#
+# This is the ideal place to do things like:
+#
+#    export DEBIAN_FRONTEND=noninteractive
+#    apt-get install -y nginx nodejs nodejs-legacy python2.7 mysql-server
+#
+# If the packages you're installing here need some configuration adjustments,
+# this is also a good place to do that:
+#
+#    sed --in-place='' \
+#            --expression 's/^user www-data/#user www-data/' \
+#            --expression 's#^pid /run/nginx.pid#pid /var/run/nginx.pid#' \
+#            --expression 's/^\s*error_log.*/error_log stderr;/' \
+#            --expression 's/^\s*access_log.*/access_log off;/' \
+#            /etc/nginx/nginx.conf
+
+# By default, this script does nothing.  You'll have to modify it as
+# appropriate for your application.
+
+export DEBIAN_FRONTEND=noninteractive
+curl -sL https://deb.nodesource.com/setup_4.x | bash -
+apt-get install -y nodejs git-core g++
+
+exit 0


### PR DESCRIPTION
Unfortunately there's not one single standardized way to deploy node apps, so this stack attempts to use the minimal reasonable defaults to get someone up and running with a node app:

* Installs the latest stable node.js (4.x)
* `npm install` and `npm start`

I think it could probably be argued that it's too minimal and the diy stack suffices. The main value is really just using nodesource to get a reasonably up to date node in the VM.