### PR TITLE
meteor stack: bump meteor-spk version to 0.1.8

### DIFF
--- a/stacks/meteor/setup.sh
+++ b/stacks/meteor/setup.sh
@@ -5,7 +5,7 @@ CURL_OPTS="--silent --show-error"
 
 cd /opt/
 
-PACKAGE=meteor-spk-0.1.7
+PACKAGE=meteor-spk-0.1.8
 PACKAGE_FILENAME="$PACKAGE.tar.xz"
 CACHE_TARGET="/host-dot-sandstorm/caches/${PACKAGE_FILENAME}"
 


### PR DESCRIPTION
Fixes a bug in migrations.  We should notify app authors to bump their versions
and `vagrant-spk destroy` and `vagrant-spk up` before their next release.