### PR TITLE
Print explanations for slow commands we are running

### DIFF
--- a/stacks/meteor/setup.sh
+++ b/stacks/meteor/setup.sh
@@ -11,7 +11,10 @@ CACHE_TARGET="/host-dot-sandstorm/caches/${PACKAGE_FILENAME}"
 
 # Fetch meteor-spk tarball if not cached
 if [ ! -f "$CACHE_TARGET" ] ; then
-    curl $CURL_OPTS https://dl.sandstorm.io/${PACKAGE_FILENAME} > "$CACHE_TARGET"
+    echo -n "Downloading ${PACKAGE}..."
+    curl $CURL_OPTS https://dl.sandstorm.io/${PACKAGE_FILENAME} > "$CACHE_TARGET.partial"
+    mv "${CACHE_TARGET}.partial" "${CACHE_TARGET}"
+    echo "...done."
 fi
 
 # Extract to /opt
@@ -37,8 +40,10 @@ METEOR_CACHE_TARGET="/host-dot-sandstorm/caches/${METEOR_TARBALL_FILENAME}"
 
 # Fetch meteor tarball if not cached
 if [ ! -f "$METEOR_CACHE_TARGET" ] ; then
+    echo -n "Downloading Meteor version ${METEOR_RELEASE}..."
     curl $CURL_OPTS "$METEOR_TARBALL_URL" > "${METEOR_CACHE_TARGET}.partial"
     mv "${METEOR_CACHE_TARGET}"{.partial,}
+    echo "...done."
 fi
 
 # Extract as unprivileged user, which is the usual meteor setup

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -141,11 +141,15 @@ curl $CURL_OPTS https://install.sandstorm.io/ > /host-dot-sandstorm/caches/insta
 SANDSTORM_CURRENT_VERSION=$(curl $CURL_OPTS -f "https://install.sandstorm.io/dev?from=0&type=install")
 SANDSTORM_PACKAGE="sandstorm-$SANDSTORM_CURRENT_VERSION.tar.xz"
 if [[ ! -f /host-dot-sandstorm/caches/$SANDSTORM_PACKAGE ]] ; then
+    echo -n "Downloading Sandstorm version ${SANDSTORM_CURRENT_VERSION}..."
     curl $CURL_OPTS --output "/host-dot-sandstorm/caches/$SANDSTORM_PACKAGE.partial" "https://dl.sandstorm.io/$SANDSTORM_PACKAGE"
     mv "/host-dot-sandstorm/caches/$SANDSTORM_PACKAGE.partial" "/host-dot-sandstorm/caches/$SANDSTORM_PACKAGE"
+    echo "...done."
 fi
 if [ ! -e /opt/sandstorm/latest/sandstorm ] ; then
+    echo -n "Installing Sandstorm version ${SANDSTORM_CURRENT_VERSION}..."
     bash /host-dot-sandstorm/caches/install.sh -d -e "/host-dot-sandstorm/caches/$SANDSTORM_PACKAGE" >/dev/null
+    echo "...done."
 fi
 modprobe ip_tables
 # Make the vagrant user part of the sandstorm group so that commands like


### PR DESCRIPTION
This applies mostly to the Meteor stack but also covers downloading
Sandstorm for all stacks.

Addresses feedback from zarvox on #74