### PR TITLE
Pin to version 8.2.1 of debian/jessie64, for vboxsf support

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -47,6 +47,9 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # We base ourselves off Debian Jessie
   config.vm.box = "debian/jessie64"
+  # We pin to base box version 8.2.1 because 8.2.2 removes support for
+  # vboxsf, aka VirtualBox file sharing.
+  config.vm.box_version = "8.2.1"
 
   if Vagrant.has_plugin?("vagrant-vbguest") then
     # vagrant-vbguest is a Vagrant plugin that upgrades


### PR DESCRIPTION
Currently doing the tutorial now, to make sure this works.

Also it sure is a shame we didn't catch this earlier. This box got released 19 days ago: https://atlas.hashicorp.com/debian/boxes/jessie64