### PR TITLE
Switch to Sandstorm snapshots of debian/jessie64, for vboxsf support

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -45,8 +45,8 @@ VM_NAME = File.basename(File.dirname(File.dirname(__FILE__))) + "_sandstorm_#{Ti
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # We base ourselves off Debian Jessie
-  config.vm.box = "debian/jessie64"
+  # Base on the Sandstorm snapshots of the official Debian 8 (jessie) box.
+  config.vm.box = "sandstorm/debian-jessie64"
 
   if Vagrant.has_plugin?("vagrant-vbguest") then
     # vagrant-vbguest is a Vagrant plugin that upgrades


### PR DESCRIPTION
I've tested this locally against the Meteor app packaging tutorial. It manages to do:

- vagrant-spk up

- vagrant-spk dev

- vagrant-spk pack (and I even uploaded & manually tested the outputted SPK)

So I think it works. @zarvox please review/merge.