### PR TITLE
Set "gzip off;" for nginx

### DIFF
--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -16,6 +16,10 @@ server {
     # limits by default.
     client_max_body_size 0;
 
+    # Prevent nginx from adding compression; this interacts badly with Sandstorm
+    # WebSession due to https://github.com/sandstorm-io/sandstorm/issues/289
+    gzip off;
+
     server_name localhost;
     root /opt/app;
     location / {

--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -35,7 +35,7 @@ server {
     }
 }
 EOF
-ln -s /etc/nginx/sites-available/sandstorm-php /etc/nginx/sites-enabled/sandstorm-php
+ln -sf /etc/nginx/sites-available/sandstorm-php /etc/nginx/sites-enabled/sandstorm-php
 service nginx stop
 service php5-fpm stop
 service mysql stop

--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y nginx php5-fpm php5-mysql php5-cli php5-curl git php5-dev mysql-server
-unlink /etc/nginx/sites-enabled/default
+rm -f /etc/nginx/sites-enabled/default
 cat > /etc/nginx/sites-available/sandstorm-php <<EOF
 server {
     listen 8000 default_server;

--- a/stacks/static/setup.sh
+++ b/stacks/static/setup.sh
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y nginx
 # Set up nginx conf
-unlink /etc/nginx/sites-enabled/default
+rm -f /etc/nginx/sites-enabled/default
 cat > /etc/nginx/sites-available/sandstorm-static <<EOF
 server {
     listen 8000 default_server;
@@ -20,7 +20,7 @@ server {
     root /opt/app;
 }
 EOF
-ln -s /etc/nginx/sites-available/sandstorm-static /etc/nginx/sites-enabled/sandstorm-static
+ln -sf /etc/nginx/sites-available/sandstorm-static /etc/nginx/sites-enabled/sandstorm-static
 # patch nginx conf to not bother trying to setuid, since we're not root
 # also patch errors to go to stderr, and logs nowhere.
 sed --in-place='' \

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y nginx mysql-server libmysqlclient-dev uwsgi uwsgi-plugin-python build-essential python-dev python-virtualenv
 # Set up nginx conf
-unlink /etc/nginx/sites-enabled/default
+rm -f /etc/nginx/sites-enabled/default
 cat > /etc/nginx/sites-available/sandstorm-python <<EOF
 server {
     listen 8000 default_server;
@@ -27,7 +27,7 @@ server {
     }
 }
 EOF
-ln -s /etc/nginx/sites-available/sandstorm-python /etc/nginx/sites-enabled/sandstorm-python
+ln -sf /etc/nginx/sites-available/sandstorm-python /etc/nginx/sites-enabled/sandstorm-python
 # patch mysql conf to not change uid
 sed --in-place='' \
         --expression='s/^user\t\t= mysql/#user\t\t= mysql/' \


### PR DESCRIPTION
This avoids a problem where HTTP 4xx and 5xx error messages are corrupted
in transit to the browser.

Close #33