### PR TITLE
Create a .gitignore file by default

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -132,8 +132,10 @@ end
 """
 
 GITIGNORE_CONTENTS = r"""
+
 # This file stores a list of sub-paths of .sandstorm/ that should be ignored by git.
 .vagrant
+
 """
 
 GLOBAL_SETUP_SCRIPT = r"""#!/bin/bash

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -131,6 +131,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 end
 """
 
+GITIGNORE_CONTENTS = r"""
+# This file stores a list of sub-paths of .sandstorm/ that should be ignored by git.
+.vagrant
+"""
+
 GLOBAL_SETUP_SCRIPT = r"""#!/bin/bash
 set -euo pipefail
 
@@ -514,6 +519,11 @@ def setup_vm(args):
     # Recursively copy in anything in the stack's service-config folder.
     source_service_config_dir = stack_plugin.plugin_file("service-config")
     target_service_config_dir = os.path.join(sandstorm_dir, "service-config")
+    # Copy in a .gitignore file.
+    gitignore_path = os.path.join(sandstorm_dir, ".gitignore")
+    with open(gitignore_path, "ab") as f:
+        f.write(GITIGNORE_CONTENTS)
+
     if os.path.exists(source_service_config_dir):
         if os.path.exists(target_service_config_dir):
             shutil.rmtree(target_service_config_dir)


### PR DESCRIPTION
Note that this is useless cruft if you are not using git. However, IMHO enough
projects use git such that it is worth adding this without bothering to detect
if this project uses git.

Close #30

(but close #30 in a very minimalist way)