### PR TITLE
Install git by default in uwsgi stack

### DIFF
--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y nginx mysql-server libmysqlclient-dev uwsgi uwsgi-plugin-python build-essential python-dev python-virtualenv
+apt-get install -y nginx mysql-server libmysqlclient-dev uwsgi uwsgi-plugin-python build-essential python-dev python-virtualenv git
 # Set up nginx conf
 rm -f /etc/nginx/sites-enabled/default
 cat > /etc/nginx/sites-available/sandstorm-python <<EOF


### PR DESCRIPTION
Pip packages can reference git remotes, which is actually done a decent bit in
the Python community.  This should help things be more likely to work out of
the box, and git doesn't pull in too many dependencies, so it shouldn't be too
painful for users that don't need it.

Closes #119