### PR TITLE
Disable mounting of /vagrant

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -117,7 +117,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     override.vm.synced_folder "..", "/opt/app"
     override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm"
-    override.vm.synced_folder "..", "/vagrant"
+    override.vm.synced_folder "..", "/vagrant", disabled: true
   end
   config.vm.provider :libvirt do |libvirt, override|
     libvirt.cpus = cpus
@@ -126,7 +126,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     override.vm.synced_folder "..", "/opt/app", type: "9p", accessmode: "passthrough"
     override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm", type: "9p", accessmode: "passthrough"
-    override.vm.synced_folder "..", "/vagrant", type: "9p", accessmode: "passthrough"
+    override.vm.synced_folder "..", "/vagrant", type: "9p", accessmode: "passthrough", disabled: true
   end
 end
 """


### PR DESCRIPTION
Libvirt refuses to mount two guest folders from the same host folder.  Since we
don't use `/vagrant` anywhere at all; preferring `/opt/app`, we can just
canonicalize on `/opt/app` and disable `/vagrant` entirely.