### PR TITLE
Add `service-config` for stacks and use in static, lemp, and uwsgi stacks

### DIFF
--- a/stacks/lemp/launcher.sh
+++ b/stacks/lemp/launcher.sh
@@ -30,4 +30,4 @@ while [ ! -e /var/run/php5-fpm.sock ] ; do
 done
 
 # Start nginx.
-/usr/sbin/nginx -g "daemon off;"
+/usr/sbin/nginx -c /opt/app/.sandstorm/service-config/nginx.conf -g "daemon off;"

--- a/stacks/lemp/service-config/mime.types
+++ b/stacks/lemp/service-config/mime.types
@@ -1,0 +1,89 @@
+
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/javascript                js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/font-woff                 woff;
+    application/java-archive              jar war ear;
+    application/json                      json;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-fontobject         eot;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
+    application/zip                       zip;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}

--- a/stacks/lemp/service-config/nginx.conf
+++ b/stacks/lemp/service-config/nginx.conf
@@ -1,0 +1,82 @@
+worker_processes 4;
+pid /var/run/nginx.pid;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+	# Basic Settings
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_names_hash_bucket_size 64;
+	server_tokens off;
+	server_name_in_redirect off;
+
+	include mime.types;
+	default_type application/octet-stream;
+
+	# Logging
+	access_log off;
+	error_log stderr;
+
+	# Prevent nginx from adding compression; this interacts badly with Sandstorm
+	# WebSession due to https://github.com/sandstorm-io/sandstorm/issues/289
+	gzip off;
+
+	# Trust the sandstorm-http-bridge's X-Forwarded-Proto.
+	map $http_x_forwarded_proto $fe_https {
+		default "";
+		https on;
+	}
+
+	server {
+		listen 8000 default_server;
+		listen [::]:8000 default_server ipv6only=on;
+
+		# Allow arbitrarily large bodies - Sandstorm can handle them, and requests
+		# are authenticated already, so there's no reason for apps to add additional
+		# limits by default.
+		client_max_body_size 0;
+
+		server_name localhost;
+		root /opt/app;
+		location / {
+			index index.php;
+			try_files $uri $uri/ =404;
+		}
+		location ~ \.php$ {
+			fastcgi_pass unix:/var/run/php5-fpm.sock;
+			fastcgi_index index.php;
+			fastcgi_split_path_info ^(.+\.php)(/.+)$;
+			fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
+			fastcgi_param  QUERY_STRING       $query_string;
+			fastcgi_param  REQUEST_METHOD     $request_method;
+			fastcgi_param  CONTENT_TYPE       $content_type;
+			fastcgi_param  CONTENT_LENGTH     $content_length;
+			
+			fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+			fastcgi_param  REQUEST_URI        $request_uri;
+			fastcgi_param  DOCUMENT_URI       $document_uri;
+			fastcgi_param  DOCUMENT_ROOT      $document_root;
+			fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+			fastcgi_param  HTTPS              $fe_https if_not_empty;
+			
+			fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+			fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+			
+			fastcgi_param  REMOTE_ADDR        $remote_addr;
+			fastcgi_param  REMOTE_PORT        $remote_port;
+			fastcgi_param  SERVER_ADDR        $server_addr;
+			fastcgi_param  SERVER_PORT        $server_port;
+			fastcgi_param  SERVER_NAME        $server_name;
+			
+			# PHP only, required if PHP was built with --enable-force-cgi-redirect
+			fastcgi_param  REDIRECT_STATUS    200;
+		}
+	}
+}

--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -5,37 +5,6 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y nginx php5-fpm php5-mysql php5-cli php5-curl git php5-dev mysql-server
-rm -f /etc/nginx/sites-enabled/default
-cat > /etc/nginx/sites-available/sandstorm-php <<EOF
-server {
-    listen 8000 default_server;
-    listen [::]:8000 default_server ipv6only=on;
-
-    # Allow arbitrarily large bodies - Sandstorm can handle them, and requests
-    # are authenticated already, so there's no reason for apps to add additional
-    # limits by default.
-    client_max_body_size 0;
-
-    # Prevent nginx from adding compression; this interacts badly with Sandstorm
-    # WebSession due to https://github.com/sandstorm-io/sandstorm/issues/289
-    gzip off;
-
-    server_name localhost;
-    root /opt/app;
-    location / {
-        index index.php;
-        try_files \$uri \$uri/ =404;
-    }
-    location ~ \\.php\$ {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
-        fastcgi_index index.php;
-        fastcgi_split_path_info ^(.+\\.php)(/.+)\$;
-        fastcgi_param  SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
-        include fastcgi_params;
-    }
-}
-EOF
-ln -sf /etc/nginx/sites-available/sandstorm-php /etc/nginx/sites-enabled/sandstorm-php
 service nginx stop
 service php5-fpm stop
 service mysql stop
@@ -70,23 +39,3 @@ innodb_log_file_size = 1048576
 # Set the main data file to grow by 1MB at a time, rather than 8MB at a time.
 innodb_autoextend_increment = 1
 EOF
-# patch nginx conf to not bother trying to setuid, since we're not root
-# also patch errors to go to stderr, and logs nowhere.
-sed --in-place='' \
-        --expression 's/^user www-data/#user www-data/' \
-        --expression 's#^pid /run/nginx.pid#pid /var/run/nginx.pid#' \
-        --expression 's/^\s*error_log.*/error_log stderr;/' \
-        --expression 's/^\s*access_log.*/access_log off;/' \
-        /etc/nginx/nginx.conf
-# Add a conf snippet providing what sandstorm-http-bridge says the protocol is as var fe_https
-cat > /etc/nginx/conf.d/50sandstorm.conf << EOF
-    # Trust the sandstorm-http-bridge's X-Forwarded-Proto.
-    map \$http_x_forwarded_proto \$fe_https {
-        default "";
-        https on;
-    }
-EOF
-# Adjust fastcgi_params to use the patched fe_https
-sed --in-place='' \
-        --expression 's/^fastcgi_param *HTTPS.*$/fastcgi_param  HTTPS               \$fe_https if_not_empty;/' \
-        /etc/nginx/fastcgi_params

--- a/stacks/static/launcher.sh
+++ b/stacks/static/launcher.sh
@@ -9,4 +9,4 @@ rm -rf /var/run
 mkdir -p /var/run
 
 # Start nginx.
-/usr/sbin/nginx -g "daemon off;"
+/usr/sbin/nginx -c /opt/app/.sandstorm/service-config/nginx.conf -g "daemon off;"

--- a/stacks/static/service-config/mime.types
+++ b/stacks/static/service-config/mime.types
@@ -1,0 +1,89 @@
+
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/javascript                js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/font-woff                 woff;
+    application/java-archive              jar war ear;
+    application/json                      json;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-fontobject         eot;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
+    application/zip                       zip;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}

--- a/stacks/static/service-config/nginx.conf
+++ b/stacks/static/service-config/nginx.conf
@@ -1,0 +1,43 @@
+worker_processes 4;
+pid /var/run/nginx.pid;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+	# Basic Settings
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_names_hash_bucket_size 64;
+	server_tokens off;
+	server_name_in_redirect off;
+
+	include mime.types;
+	default_type application/octet-stream;
+
+	# Logging
+	access_log off;
+	error_log stderr;
+
+	# Prevent nginx from adding compression; this interacts badly with Sandstorm
+	# WebSession due to https://github.com/sandstorm-io/sandstorm/issues/289
+	gzip off;
+
+	server {
+		listen 8000 default_server;
+		listen [::]:8000 default_server ipv6only=on;
+
+		# Allow arbitrarily large bodies - Sandstorm can handle them, and requests
+		# are authenticated already, so there's no reason for apps to add additional
+		# limits by default.
+		client_max_body_size 0;
+
+		server_name localhost;
+		root /opt/app;
+	}
+}

--- a/stacks/static/setup.sh
+++ b/stacks/static/setup.sh
@@ -4,30 +4,5 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y nginx
-# Set up nginx conf
-rm -f /etc/nginx/sites-enabled/default
-cat > /etc/nginx/sites-available/sandstorm-static <<EOF
-server {
-    listen 8000 default_server;
-    listen [::]:8000 default_server ipv6only=on;
-
-    # Allow arbitrarily large bodies - Sandstorm can handle them, and requests
-    # are authenticated already, so there's no reason for apps to add additional
-    # limits by default.
-    client_max_body_size 0;
-
-    server_name localhost;
-    root /opt/app;
-}
-EOF
-ln -sf /etc/nginx/sites-available/sandstorm-static /etc/nginx/sites-enabled/sandstorm-static
-# patch nginx conf to not bother trying to setuid, since we're not root
-# also patch errors to go to stderr, and logs nowhere.
-sed --in-place='' \
-        --expression 's/^user www-data/#user www-data/' \
-        --expression 's#^pid /run/nginx.pid#pid /var/run/nginx.pid#' \
-        --expression 's/^\s*error_log.*/error_log stderr;/' \
-        --expression 's/^\s*access_log.*/access_log off;/' \
-        /etc/nginx/nginx.conf
 service nginx stop
 systemctl disable nginx

--- a/stacks/uwsgi/launcher.sh
+++ b/stacks/uwsgi/launcher.sh
@@ -41,5 +41,5 @@ while [ ! -e $UWSGI_SOCKET_FILE ] ; do
 done
 
 # Start nginx.
-/usr/sbin/nginx -g "daemon off;"
+/usr/sbin/nginx -c /opt/app/.sandstorm/service-config/nginx.conf -g "daemon off;"
 

--- a/stacks/uwsgi/service-config/mime.types
+++ b/stacks/uwsgi/service-config/mime.types
@@ -1,0 +1,89 @@
+
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/javascript                js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/font-woff                 woff;
+    application/java-archive              jar war ear;
+    application/json                      json;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-fontobject         eot;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
+    application/zip                       zip;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}

--- a/stacks/uwsgi/service-config/nginx.conf
+++ b/stacks/uwsgi/service-config/nginx.conf
@@ -1,0 +1,70 @@
+worker_processes 4;
+pid /var/run/nginx.pid;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+	# Basic Settings
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_names_hash_bucket_size 64;
+	server_tokens off;
+	server_name_in_redirect off;
+
+	include mime.types;
+	default_type application/octet-stream;
+
+	# Logging
+	access_log off;
+	error_log stderr;
+
+	# Prevent nginx from adding compression; this interacts badly with Sandstorm
+	# WebSession due to https://github.com/sandstorm-io/sandstorm/issues/289
+	gzip off;
+
+	# Trust the sandstorm-http-bridge's X-Forwarded-Proto.
+	map $http_x_forwarded_proto $fe_https {
+		default "";
+		https on;
+	}
+
+	server {
+		listen 8000 default_server;
+		listen [::]:8000 default_server ipv6only=on;
+
+		# Allow arbitrarily large bodies - Sandstorm can handle them, and requests
+		# are authenticated already, so there's no reason for apps to add additional
+		# limits by default.
+		client_max_body_size 0;
+
+		server_name localhost;
+		root /opt/app;
+		location /static/ {
+			alias /opt/app/static/;
+		}
+		location / {
+			uwsgi_pass unix:///var/run/uwsgi.sock;
+			uwsgi_param  QUERY_STRING       $query_string;
+			uwsgi_param  REQUEST_METHOD     $request_method;
+			uwsgi_param  CONTENT_TYPE       $content_type;
+			uwsgi_param  CONTENT_LENGTH     $content_length;
+
+			uwsgi_param  REQUEST_URI        $request_uri;
+			uwsgi_param  PATH_INFO          $document_uri;
+			uwsgi_param  DOCUMENT_ROOT      $document_root;
+			uwsgi_param  SERVER_PROTOCOL    $server_protocol;
+			uwsgi_param  HTTPS              $fe_https if_not_empty;
+
+			uwsgi_param  REMOTE_ADDR        $remote_addr;
+			uwsgi_param  REMOTE_PORT        $remote_port;
+			uwsgi_param  SERVER_PORT        $server_port;
+			uwsgi_param  SERVER_NAME        $server_name;
+		}
+	}
+}

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -4,30 +4,6 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y nginx mysql-server libmysqlclient-dev uwsgi uwsgi-plugin-python build-essential python-dev python-virtualenv git
-# Set up nginx conf
-rm -f /etc/nginx/sites-enabled/default
-cat > /etc/nginx/sites-available/sandstorm-python <<EOF
-server {
-    listen 8000 default_server;
-    listen [::]:8000 default_server ipv6only=on;
-
-    # Allow arbitrarily large bodies - Sandstorm can handle them, and requests
-    # are authenticated already, so there's no reason for apps to add additional
-    # limits by default.
-    client_max_body_size 0;
-
-    server_name localhost;
-    root /opt/app;
-    location /static/ {
-        alias /opt/app/static/;
-    }
-    location / {
-        uwsgi_pass unix:///var/run/uwsgi.sock;
-        include uwsgi_params;
-    }
-}
-EOF
-ln -sf /etc/nginx/sites-available/sandstorm-python /etc/nginx/sites-enabled/sandstorm-python
 # patch mysql conf to not change uid
 sed --in-place='' \
         --expression='s/^user\t\t= mysql/#user\t\t= mysql/' \
@@ -40,14 +16,6 @@ innodb_log_file_size = 1048576
 # Set the main data file to grow by 1MB at a time, rather than 8MB at a time.
 innodb_autoextend_increment = 1
 EOF
-# patch nginx conf to not bother trying to setuid, since we're not root
-# also patch errors to go to stderr, and logs nowhere.
-sed --in-place='' \
-        --expression 's/^user www-data/#user www-data/' \
-        --expression 's#^pid /run/nginx.pid#pid /var/run/nginx.pid#' \
-        --expression 's/^\s*error_log.*/error_log stderr;/' \
-        --expression 's/^\s*access_log.*/access_log off;/' \
-        /etc/nginx/nginx.conf
 service nginx stop
 service mysql stop
 systemctl disable nginx

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -511,6 +511,14 @@ def setup_vm(args):
     with open(vagrantfile_path, "w") as f:
         f.write(VAGRANTFILE_CONTENTS)
 
+    # Recursively copy in anything in the stack's service-config folder.
+    source_service_config_dir = stack_plugin.plugin_file("service-config")
+    target_service_config_dir = os.path.join(sandstorm_dir, "service-config")
+    if os.path.exists(source_service_config_dir):
+        if os.path.exists(target_service_config_dir):
+            shutil.rmtree(target_service_config_dir)
+        shutil.copytree(source_service_config_dir, target_service_config_dir)
+
     # Make a note of which stack was used
     stack_path = os.path.join(sandstorm_dir, "stack")
     with open(stack_path, "w") as f:


### PR DESCRIPTION
`vagrant-spk setupvm <stack>` will now recursively copy that stack's `service-config` to `$PWD/.sandstorm/service-config`.

Then, we migrate the `static`, `lemp`, and `uwsgi` stacks to use this new functionality for their nginx confs, rather than doing messy patches atop Debian's default configs.

Tested successfully against:

* a minimal `static` stack "app" that just serves an `index.html`
* https://github.com/paulproteus/php-app-to-package-for-sandstorm
* https://github.com/zarvox/python-app-to-package-for-sandstorm

Closes #116.