### PR TITLE
setup.sh: Provide a more intense warning & docs link

### DIFF
--- a/stacks/diy/setup.sh
+++ b/stacks/diy/setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+
+# When you change this file, you must take manual action. Read this doc:
+# - https://docs.sandstorm.io/en/latest/vagrant-spk/customizing/#setupsh
+
 set -euo pipefail
-# This script is run in the VM once when you first run `vagrant-spk up`.  It is
-# useful for installing system-global dependencies.  It is run exactly once
-# over the lifetime of the VM.
-#
 # This is the ideal place to do things like:
 #
 #    export DEBIAN_FRONTEND=noninteractive

--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# When you change this file, you must take manual action. Read this doc:
+# - https://docs.sandstorm.io/en/latest/vagrant-spk/customizing/#setupsh
+
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive

--- a/stacks/lesp/setup.sh
+++ b/stacks/lesp/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# When you change this file, you must take manual action. Read this doc:
+# - https://docs.sandstorm.io/en/latest/vagrant-spk/customizing/#setupsh
+
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive

--- a/stacks/meteor/setup.sh
+++ b/stacks/meteor/setup.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# When you change this file, you must take manual action. Read this doc:
+# - https://docs.sandstorm.io/en/latest/vagrant-spk/customizing/#setupsh
+
 set -euo pipefail
 
 CURL_OPTS="--silent --show-error"

--- a/stacks/node/setup.sh
+++ b/stacks/node/setup.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
-set -euo pipefail
-# This script is run in the VM once when you first run `vagrant-spk up`.  It is
-# useful for installing system-global dependencies.  It is run exactly once
-# over the lifetime of the VM.
-#
 
+# When you change this file, you must take manual action. Read this doc:
+# - https://docs.sandstorm.io/en/latest/vagrant-spk/customizing/#setupsh
+
+set -euo pipefail
 # Install node.js
 
 # Discussion, issues and change requests at:

--- a/stacks/static/setup.sh
+++ b/stacks/static/setup.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# When you change this file, you must take manual action. Read this doc:
+# - https://docs.sandstorm.io/en/latest/vagrant-spk/customizing/#setupsh
+
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# When you change this file, you must take manual action. Read this doc:
+# - https://docs.sandstorm.io/en/latest/vagrant-spk/customizing/#setupsh
+
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
@@ -20,4 +24,3 @@ service nginx stop
 service mysql stop
 systemctl disable nginx
 systemctl disable mysql
-


### PR DESCRIPTION
Rationale:

- @grantpotter emailed me to ask why his vagrant-spk box wasn't being modified
  in accordance with his changes to setup.sh. I believe he didn't understand the
  comment text in the existing setup.sh because he doesn't have a clear concept
  of the boundary between vagrant and vagrant-spk.

- Therefore, I think he would have benefited from a more intense warning plus a
  link to the docs.