### PR TITLE
Insist that *.sh files are LF not CRLF

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -131,6 +131,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 end
 """
 
+GITATTRIBUTES_CONTENTS = r"""
+
+# vagrant-spk creates shell scripts, which must end in \n, even on a \r\n system.
+*.sh text eol=lf
+
+"""
+
 GITIGNORE_CONTENTS = r"""
 
 # This file stores a list of sub-paths of .sandstorm/ that should be ignored by git.
@@ -521,10 +528,16 @@ def setup_vm(args):
     # Recursively copy in anything in the stack's service-config folder.
     source_service_config_dir = stack_plugin.plugin_file("service-config")
     target_service_config_dir = os.path.join(sandstorm_dir, "service-config")
-    # Copy in a .gitignore file.
+
+    # Copy in a .gitignore file. See https://github.com/sandstorm-io/vagrant-spk/issues/30
     gitignore_path = os.path.join(sandstorm_dir, ".gitignore")
     with open(gitignore_path, "ab") as f:
         f.write(GITIGNORE_CONTENTS)
+
+    # Copy in a .gitattributes file. See https://github.com/sandstorm-io/vagrant-spk/issues/55
+    gitattributes_path = os.path.join(sandstorm_dir, ".gitattributes")
+    with open(gitattributes_path, "ab") as f:
+        f.write(GITATTRIBUTES_CONTENTS)
 
     if os.path.exists(source_service_config_dir):
         if os.path.exists(target_service_config_dir):


### PR DESCRIPTION
Close #55

Testing done:

- Run `vagrant-spk setupvm`

- Notice that a `.gitattributes` file indeed got created

- Ran git command to verify attributes.

```
➜  php-app-to-package-for-sandstorm git:(master) git check-attr -a .sandstorm/*.sh
.sandstorm/build.sh: text: set
.sandstorm/build.sh: eol: lf
.sandstorm/global-setup.sh: text: set
.sandstorm/global-setup.sh: eol: lf
.sandstorm/launcher.sh: text: set
.sandstorm/launcher.sh: eol: lf
.sandstorm/setup.sh: text: set
.sandstorm/setup.sh: eol: lf
```

Given that, I think this is OK to merge as-is. @zarvox requesting your +1/-1 on this.

@mautic thanks for your patience with us as we took a while to resolve this.