### PR TITLE
vagrant-spk: publish shouldn't crash if user gives no .spk arg

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -611,7 +611,7 @@ def publish(args):
     if len(args.command_specific_args) == 0:
         print("Please specify an .spk file to publish - e.g.")
         print("  vagrant-spk publish example.spk")
-        return
+        sys.exit(1)
     # Sadly, we have to copy the spk into the VM since it could be anywhere on the host filesystem
     spk = args.command_specific_args[0]
     sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -608,6 +608,10 @@ def verify(args):
         os.remove(temp_spk)
 
 def publish(args):
+    if len(args.command_specific_args) == 0:
+        print("Please specify an .spk file to publish - e.g.")
+        print("  vagrant-spk publish example.spk")
+        return
     # Sadly, we have to copy the spk into the VM since it could be anywhere on the host filesystem
     spk = args.command_specific_args[0]
     sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")


### PR DESCRIPTION
As observed by `synchrone` on IRC.