### PR TITLE
Move all vagrant passthrough subcommands under the "vm" subcommand

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -645,7 +645,15 @@ def publish(args):
         os.remove(temp_spk)
 
 def warn_deprecated(command_name):
-    sys.stderr.write("WARNING: `vagrant-spk {0}` is deprecated and may be removed in the future.\nPrefer `vagrant-spk vm {0}`.\n".format(command_name))
+    ANSI_RED = "\x1b[31m"
+    ANSI_RESET = "\x1b[0m"
+    message = "\n".join([
+      ANSI_RED + "WARNING: `vagrant-spk {0}` is deprecated and will be removed on August 1, 2016.".format(command_name),
+      "Prefer `vagrant-spk vm {0}`.".format(command_name),
+      ANSI_RESET + "For more information, see https://groups.google.com/forum/#!topic/sandstorm-dev/cuSNJ3IsP6I",
+      ""
+    ])
+    sys.stderr.write(message)
 
 def deprecated_halt(args):
     warn_deprecated("halt")

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -742,6 +742,9 @@ def main():
         Command('vm', vm_subcommand,
             "Pass through all subsequent arguments to `vagrant` run in `.sandstorm`."),
         Command('vm up', None, "Start the Vagrant VM (and build the VM image if needed)"),
+        Command('vm halt', None, "Shut down the Vagrant VM."),
+        Command('vm destroy', None, "Delete the Vagrant VM (but leave --work-directory untouched)."),
+        Command('vm ssh', None, "SSH into the Vagrant VM."),
         Command('init', init,
             "Initialize fresh Sandstorm package definition \n"
             "  resources in --work-directory."),
@@ -756,9 +759,6 @@ def main():
         Command('publish', publish,
             "Send the current packed app spk to \n"
             "  the Sandstorm App Market."),
-        Command('vm halt', None, "Shut down the Vagrant VM."),
-        Command('vm destroy', None, "Delete the Vagrant VM (but leave --work-directory untouched)."),
-        Command('vm ssh', None, "SSH into the Vagrant VM."),
         Command('keygen', keygen,
             "Generate a new key, add it to your keyring,\n"
             "  and print the identifier."),

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -565,6 +565,10 @@ def setup_vm(args):
     with open(stack_path, "w") as f:
         f.write(stack_plugin_name + "\n")
 
+def deprecated_bring_up_vm(args):
+    warn_deprecated("up")
+    bring_up_vm(args)
+
 def bring_up_vm(args):
     sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")
     # Make sure ~/.sandstorm exists, since global-setup.sh uses
@@ -640,22 +644,30 @@ def publish(args):
     finally:
         os.remove(temp_spk)
 
-def halt(args):
+def warn_deprecated(command_name):
+    sys.stderr.write("WARNING: `vagrant-spk {0}` is deprecated and may be removed in the future.\nPrefer `vagrant-spk vm {0}`.\n".format(command_name))
+
+def deprecated_halt(args):
+    warn_deprecated("halt")
     sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")
     call_vagrant_command(sandstorm_dir, "halt")
 
-def do_reload(args):
+def deprecated_do_reload(args):
+    warn_deprecated("reload")
     sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")
     call_vagrant_command(sandstorm_dir, "reload")
 
-def destroy(args):
+def deprecated_destroy(args):
+    warn_deprecated("destroy")
     sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")
     call_vagrant_command(sandstorm_dir, "destroy", "--force")
 
-def global_status(args):
+def deprecated_global_status(args):
+    warn_deprecated("global_status")
     return subprocess.check_call(["vagrant", "global-status"])
 
-def ssh(args):
+def deprecated_ssh(args):
+    warn_deprecated("ssh")
     sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")
     call_vagrant_command(sandstorm_dir, "ssh")
 
@@ -676,6 +688,28 @@ def getkey(args):
                        # so we make sure to disable TTY allocation.
             )
 
+def vm_subcommand(args):
+    sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")
+    if len(args.command_specific_args) == 0:
+        sys.stderr.write("Try specifying a command to pass through to vagrant, like\n\nvagrant-spk vm up\n\n")
+        sys.exit(1)
+
+    # Do a couple sanity checks.
+    ensure_host_sandstorm_folder_exists()
+    if not os.path.exists(sandstorm_dir) or not os.path.exists(os.path.join(sandstorm_dir, "Vagrantfile")):
+        sys.stderr.write("You can't call `vm` commands if there's no `.sandstorm` folder.\n" +
+                "Try `vagrant-spk setupvm <stack>` first.\n")
+        sys.exit(1)
+
+    subcommand = args.command_specific_args[0]
+    # Do subcommand specific sanity checks.
+    if subcommand == 'up':
+        # Sanity-check that the user will get a Vagrant box that supports vboxsf, since
+        # vagrant-spk depends on that for now.
+        ensure_working_vboxsf_in_base_box(sandstorm_dir)
+
+    call_vagrant_command(sandstorm_dir, *args.command_specific_args)
+
 def main():
     global ENABLE_EXPERIMENTAL
     # Switch on feature(s) that we don't think are ready for everyone.
@@ -688,7 +722,7 @@ def main():
             "  --work-directory (using the provided `stack` \n"
             "  command arg).  Also inits developer keys in \n"
             "  ~/.sandstorm on this host."),
-        ('up', bring_up_vm,
+        ('up', deprecated_bring_up_vm,
             "Start the Vagrant VM (and build the VM image \n"
             "  if necessary)."),
         ('init', init,
@@ -705,24 +739,26 @@ def main():
         ('publish', publish,
             "Send the current packed app spk to \n"
             "  the Sandstorm App Market."),
-        ('halt', halt,
-            "Shut down the Vagrant VM."),
-        ('destroy', destroy,
-            "Delete the Vagrant VM (but leave \n"
+        ('vm', vm_subcommand,
+            "Pass through all following arguments to `vagrant`."),
+        ('halt', deprecated_halt,
+            "(deprecated, use 'vm halt') Shut down the Vagrant VM."),
+        ('destroy', deprecated_destroy,
+            "(deprecated, use 'vm destroy') Delete the Vagrant VM (but leave \n"
             "  --work-directory untouched)."),
-        ('global-status', global_status,
-            "Show the state of all active \n"
+        ('global-status', deprecated_global_status,
+            "(deprecated, use 'vm global-status') Show the state of all active \n"
             "  Vagrant VMs on this host."),
-        ('ssh', ssh,
-            "SSH into the Vagrant VM."),
+        ('ssh', deprecated_ssh,
+            "(deprecated, use 'vm ssh') SSH into the Vagrant VM."),
         ('keygen', keygen,
             "Generate a new key, add it to your keyring,\n"
             "  and print the identifier."),
         ('getkey', getkey,
             "Given a key identifier, retrieve and print the\n"
             "  corresponding private key from your keyring."),
-        ('reload', do_reload,
-            "Reboot the virtual machine, turning it off then on."),
+        ('reload', deprecated_do_reload,
+            "(deprecated, use 'vm reload') Reboot the virtual machine, turning it off then on."),
     ]
 
     if ENABLE_EXPERIMENTAL:

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -718,6 +718,15 @@ def vm_subcommand(args):
 
     call_vagrant_command(sandstorm_dir, *args.command_specific_args)
 
+
+class Command(object):
+    def __init__(self, name, func, helptext, hidden=False):
+        self.name = name
+        self.func = func # func may be None if this is intended only for the help text
+        self.helptext = helptext
+        self.hidden = hidden # if true, do not show in vagrant-spk --help
+
+
 def main():
     global ENABLE_EXPERIMENTAL
     # Switch on feature(s) that we don't think are ready for everyone.
@@ -725,62 +734,69 @@ def main():
         ENABLE_EXPERIMENTAL = True
 
     operations = [
-        ('setupvm', setup_vm,
+        Command('setupvm', setup_vm,
             "Set up a fresh app environment in \n"
             "  --work-directory (using the provided `stack` \n"
             "  command arg).  Also inits developer keys in \n"
             "  ~/.sandstorm on this host."),
-        ('up', deprecated_bring_up_vm,
-            "Start the Vagrant VM (and build the VM image \n"
-            "  if necessary)."),
-        ('init', init,
+        Command('vm', vm_subcommand,
+            "Pass through all subsequent arguments to `vagrant` run in `.sandstorm`."),
+        Command('vm up', None, "Start the Vagrant VM (and build the VM image if needed)"),
+        Command('init', init,
             "Initialize fresh Sandstorm package definition \n"
             "  resources in --work-directory."),
-        ('dev', dev,
+        Command('dev', dev,
             "Make the current app available to Sandstorm \n"
             "  in dev mode (after bringing the Vagrant VM `up`)"),
-        ('pack', pack,
+        Command('pack', pack,
             "Pack the curent app into a \n"
             "  Sandstorm package."),
-        ('verify', verify,
+        Command('verify', verify,
             "Show details of the specified Sandstorm package."),
-        ('publish', publish,
+        Command('publish', publish,
             "Send the current packed app spk to \n"
             "  the Sandstorm App Market."),
-        ('vm', vm_subcommand,
-            "Pass through all following arguments to `vagrant`."),
-        ('halt', deprecated_halt,
-            "(deprecated, use 'vm halt') Shut down the Vagrant VM."),
-        ('destroy', deprecated_destroy,
-            "(deprecated, use 'vm destroy') Delete the Vagrant VM (but leave \n"
-            "  --work-directory untouched)."),
-        ('global-status', deprecated_global_status,
-            "(deprecated, use 'vm global-status') Show the state of all active \n"
-            "  Vagrant VMs on this host."),
-        ('ssh', deprecated_ssh,
-            "(deprecated, use 'vm ssh') SSH into the Vagrant VM."),
-        ('keygen', keygen,
+        Command('vm halt', None, "Shut down the Vagrant VM."),
+        Command('vm destroy', None, "Delete the Vagrant VM (but leave --work-directory untouched)."),
+        Command('vm ssh', None, "SSH into the Vagrant VM."),
+        Command('keygen', keygen,
             "Generate a new key, add it to your keyring,\n"
             "  and print the identifier."),
-        ('getkey', getkey,
+        Command('getkey', getkey,
             "Given a key identifier, retrieve and print the\n"
             "  corresponding private key from your keyring."),
-        ('reload', deprecated_do_reload,
-            "(deprecated, use 'vm reload') Reboot the virtual machine, turning it off then on."),
+
+        # Below here are deprecated functions that we don't want to show in the help,
+        # but which we still need to dispatch until August 1, 2016.
+        Command('up', deprecated_bring_up_vm,
+            "(deprecated, use 'vagrant-spk vm halt') Start the Vagrant VM\n"
+            "  (and build the VM image if necessary).", hidden=True),
+        Command('reload', deprecated_do_reload,
+            "(deprecated, use 'vagrant-spk vm reload') Reboot the virtual machine, turning it off then on."),
+        Command('halt', deprecated_halt,
+            "(deprecated, use 'vagrant-spk vm halt') Shut down the Vagrant VM.", hidden=True),
+        Command('destroy', deprecated_destroy,
+            "(deprecated, use 'vagrant-spk vm destroy') Delete the Vagrant VM (but leave \n"
+            "  --work-directory untouched).", hidden=True),
+        Command('global-status', deprecated_global_status,
+            "(deprecated, use 'vagrant-spk vm global-status') Show the state of all active \n"
+            "  Vagrant VMs on this host.", hidden=True),
+        Command('ssh', deprecated_ssh,
+            "(deprecated, use 'vagrant-spk vm ssh') SSH into the Vagrant VM.", hidden=True),
     ]
 
     if ENABLE_EXPERIMENTAL:
         operations.append(
-            ('auto', auto,
+            Command('auto', auto,
              "Automatically package the app in \n"
              "  --work-directory (using the provided `stack` \n"
              "  command arg. Also inits developer keys in \n"
              "  ~/.sandstorm on this host. (EXPERIMENTAL)"))
 
-    op_to_func = dict((cmd, f) for cmd, f, helptext in operations)
-    ops_helptext = '\n'.join(cmd + ': ' + helptext for cmd, f, helptext in operations)
+    op_to_func = dict((c.name, c.func) for c in operations if c.func)
+    ops_helptext = '\n'.join(c.name + ': ' + c.helptext for c in operations if not c.hidden)
     parser = argparse.ArgumentParser(prog=sys.argv[0], formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument("command", choices=[cmd for cmd, _, _ in operations], help=ops_helptext)
+    parser.add_argument("command", choices=[c.name for c in operations], help=ops_helptext)
     parser.add_argument("command_specific_args", nargs="*")
     parser.add_argument(
         "--work-directory",


### PR DESCRIPTION
In an attempt to clean up the command surface of vagrant-spk, all commands
intended to forward directly to vagrant are now placed under the "vm"
subcommand.

The "up", "ssh", "destroy", "global-status", and "reload" commands are
deprecated in favor of the "vm <subcommand>" equivalents, but will continue to
work with a warning until some future release.

This change also means we can reasonably pass through *any* arguments passed to
`vagrant-spk vm` on to `vagrant`, so we're no longer in the business of
whitelisting arguments and reimplementing all the commands that `vagrant`
provides that people might want to use.