### PR TITLE
libvirt HOWTO: Debian calls it libvirt-bin

### DIFF
--- a/HOWTO-libvirt.md
+++ b/HOWTO-libvirt.md
@@ -26,7 +26,7 @@ sudo dnf install virt-manager libvirt libvirt-daemon
 On Debian/Ubuntu:
 
 ```
-sudo apt-get install libvirtd virt-manager
+sudo apt-get install libvirt-bin virt-manager
 ```
 
 


### PR DESCRIPTION
`libvirtd` is nonexistent, so I assume it's this. Will self-merge because we decided these docs need little review, but post-merge review very much welcome.