### PR TITLE
For some calls to curl, buffer output via pipe to cat

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -162,13 +162,18 @@ GITIGNORE_CONTENTS = r"""
 GLOBAL_SETUP_SCRIPT = r"""#!/bin/bash
 set -euo pipefail
 
-# Set options for curl. Since we only want to show errors from these curl
-# commands, we also use 'cat' to buffer the output; for more information:
+# Set options for curl. Since we only want to show errors from these curl commands, we also use
+# 'cat' to buffer the output; for more information:
 # https://github.com/sandstorm-io/vagrant-spk/issues/158
+
 CURL_OPTS="--silent --show-error"
 echo localhost > /etc/hostname
 hostname localhost
+
+# The following line copies stderr through stderr to cat without accidentally leaving it in the
+# output file. See: https://github.com/sandstorm-io/vagrant-spk/pull/159
 curl $CURL_OPTS https://install.sandstorm.io/ 2>&1 > /host-dot-sandstorm/caches/install.sh | cat
+
 SANDSTORM_CURRENT_VERSION=$(curl $CURL_OPTS -f "https://install.sandstorm.io/dev?from=0&type=install")
 SANDSTORM_PACKAGE="sandstorm-$SANDSTORM_CURRENT_VERSION.tar.xz"
 if [[ ! -f /host-dot-sandstorm/caches/$SANDSTORM_PACKAGE ]] ; then

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -162,15 +162,18 @@ GITIGNORE_CONTENTS = r"""
 GLOBAL_SETUP_SCRIPT = r"""#!/bin/bash
 set -euo pipefail
 
+# Set options for curl. Since we only want to show errors from these curl
+# commands, we also use 'cat' to buffer the output; for more information:
+# https://github.com/sandstorm-io/vagrant-spk/issues/158
 CURL_OPTS="--silent --show-error"
 echo localhost > /etc/hostname
 hostname localhost
-curl $CURL_OPTS https://install.sandstorm.io/ > /host-dot-sandstorm/caches/install.sh
+curl $CURL_OPTS https://install.sandstorm.io/ 2>&1 > /host-dot-sandstorm/caches/install.sh | cat
 SANDSTORM_CURRENT_VERSION=$(curl $CURL_OPTS -f "https://install.sandstorm.io/dev?from=0&type=install")
 SANDSTORM_PACKAGE="sandstorm-$SANDSTORM_CURRENT_VERSION.tar.xz"
 if [[ ! -f /host-dot-sandstorm/caches/$SANDSTORM_PACKAGE ]] ; then
     echo -n "Downloading Sandstorm version ${SANDSTORM_CURRENT_VERSION}..."
-    curl $CURL_OPTS --output "/host-dot-sandstorm/caches/$SANDSTORM_PACKAGE.partial" "https://dl.sandstorm.io/$SANDSTORM_PACKAGE"
+    curl $CURL_OPTS --output "/host-dot-sandstorm/caches/$SANDSTORM_PACKAGE.partial" "https://dl.sandstorm.io/$SANDSTORM_PACKAGE" 2>&1 | cat
     mv "/host-dot-sandstorm/caches/$SANDSTORM_PACKAGE.partial" "/host-dot-sandstorm/caches/$SANDSTORM_PACKAGE"
     echo "...done."
 fi

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -171,7 +171,7 @@ echo localhost > /etc/hostname
 hostname localhost
 
 # The following line copies stderr through stderr to cat without accidentally leaving it in the
-# output file. See: https://github.com/sandstorm-io/vagrant-spk/pull/159
+# output file. Be careful when changing. See: https://github.com/sandstorm-io/vagrant-spk/pull/159
 curl $CURL_OPTS https://install.sandstorm.io/ 2>&1 > /host-dot-sandstorm/caches/install.sh | cat
 
 SANDSTORM_CURRENT_VERSION=$(curl $CURL_OPTS -f "https://install.sandstorm.io/dev?from=0&type=install")


### PR DESCRIPTION
Close: #158 

## Explanation of this implementation strategy

This changeset:

- Adjusts the default `global-setup.sh` so that the two `curl` calls that currently only print error messages now print them error messages through a pipe to cat.

- This has the effect of buffering them, which helps vagrant receive the error messages all at once, in my manual testing.

- Assuming this is implemented correctly, this retains all the same information as before. Any error messages that we were printing before, we are still printing. I know that @zarvox is interested in making sure that we retain the existing discoverability and comprehensibility of `vagrant-spk`.

## Other research

Here is my proof that the very subtle change on the first line is a safe change to make.

```
paulproteus@slittingmill:~$ cat << EOF > /tmp/print-to-both.sh
> #!/bin/bash
> echo stdout
> echo stderr 1>&2
> EOF
paulproteus@slittingmill:~$ bash /tmp/print-to-both.sh 
stdout
stderr
paulproteus@slittingmill:~$ bash /tmp/print-to-both.sh  > /dev/null
stderr
paulproteus@slittingmill:~$ bash /tmp/print-to-both.sh 2>&1 > /dev/null | cat
stderr
paulproteus@slittingmill:~$ bash /tmp/print-to-both.sh 2>&1 > /tmp/some-filename | cat
stderr
paulproteus@slittingmill:~$ cat /tmp/some-filename 
stdout
paulproteus@slittingmill:~$ 
```

### To reproduce the problem

Modify `CURL_OPTS` to also add ` --max-time 1` for a maximum wait of 1 second for the download.

## Next steps

@zarvox if you're willing to be the one to review/merge this, I'd appreciate that. Otherwise I might self-merge on Friday evening.