### PR TITLE
Add helpers to Windows build

### DIFF
--- a/windows-support/Makefile
+++ b/windows-support/Makefile
@@ -28,7 +28,7 @@ vendor/python.msi.installed: | vendor/python.msi
 	touch vendor/python.msi.installed
 
 state/wineprefix/drive_c/Python27/Scripts/pyinstaller.exe: | vendor/python.msi.installed vendor/pywin32.exe.installed
-	$(WINEARGS) $(WINE) 'c:/python27/python.exe' -m pip install pyinstaller
+	$(WINEARGS) $(WINE) 'c:/python27/python.exe' -m pip install pyinstaller==3.1.1
 
 vendor/pywin32.exe: | vendor
 	wget http://iweb.dl.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py2.7.exe -O vendor/pywin32.exe

--- a/windows-support/windows-installer.iss
+++ b/windows-support/windows-installer.iss
@@ -41,6 +41,9 @@ Source: "dist\vagrant-spk.exe"; DestDir: "{app}"; Flags: ignoreversion
 ; vagrant-spk platform stacks
 Source: "..\stacks\*"; DestDir: "{app}\stacks"; Flags: recursesubdirs
 
+; "helpers" - right now just the enter_grain binary and its sha1
+Source: "..\helpers\*"; DestDir: "{app}\helpers"; Flags: recursesubdirs
+
 ; ssh binary + required DLLs, so that `vagrant ssh` can work
 Source: "vendor\msysgit\ssh.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "vendor\msysgit\msys-crypto-1.0.0.dll"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
Also pin to version 3.1.1 of pyinstaller, which manages to build our program OK.