### PR TITLE
Reduce the size of `enter_grain` by 80%

### DIFF
--- a/helpers/Makefile
+++ b/helpers/Makefile
@@ -3,7 +3,7 @@ all: enter_grain.sha1
 .PHONY: enter_grain
 
 enter_grain:
-	cd enter-grain-source && cargo build --release && cp target/release/enter_grain ../
+	cd enter-grain-source && cargo build --release && strip target/release/enter_grain && cp target/release/enter_grain ../
 
 enter_grain.sha1: enter_grain
 	sha1sum enter_grain > enter_grain.sha1

--- a/helpers/enter-grain-source/Cargo.toml
+++ b/helpers/enter-grain-source/Cargo.toml
@@ -5,3 +5,7 @@ authors = ["Asheesh Laroia"]
 
 [dependencies]
 syscall = "0.2.1"
+
+[profile.release]
+opt-level = 3
+lto = true

--- a/helpers/enter-grain-source/src/main.rs
+++ b/helpers/enter-grain-source/src/main.rs
@@ -1,3 +1,6 @@
+#![feature(alloc_system)]
+extern crate alloc_system;
+
 // use std::env;
 use std::fs::File;
 use std::io::Read;


### PR DESCRIPTION
With this change, we:

* enable link-time optimization
* use the system allocator over jemalloc
* strip the binary to remove debugging symbols

This reduces the binary size from 644k to 131k.

@paulproteus I didn't update the checked-in `enter_grain` binary or shasum; let me know if you'd like me to do so.  Tragically, any changes we make just make the git tree larger, so I'm not sure checking in non-bugfixes for the binaries is actually a net win.