### PR TITLE
Do not rely on launcher.sh being executable

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -670,7 +670,7 @@ def init(args):
     stack_plugin = StackPlugin(stack)
     init_args = stack_plugin.init_args()
     # Initialize the package with spk init
-    call_vagrant_command(sandstorm_dir, "ssh", "-c", "spk init -p 8000 --keyring=/host-dot-sandstorm/sandstorm-keyring --output=/opt/app/.sandstorm/sandstorm-pkgdef.capnp {} -- /opt/app/.sandstorm/launcher.sh".format(init_args))
+    call_vagrant_command(sandstorm_dir, "ssh", "-c", "spk init -p 8000 --keyring=/host-dot-sandstorm/sandstorm-keyring --output=/opt/app/.sandstorm/sandstorm-pkgdef.capnp {} -- /bin/bash /opt/app/.sandstorm/launcher.sh".format(init_args))
 
 def dev(args):
     sandstorm_dir = os.path.join(args.work_directory, ".sandstorm")


### PR DESCRIPTION
Context: https://github.com/pgrm/swagger-editor-sandstorm/issues/4
