### PR TITLE
Update Vagrant-SPK to support Windows10 hosts

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -74,7 +74,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # We forward port 6080, the Sandstorm web port, so that developers can
   # visit their sandstorm app from their browser as local.sandstorm.io:6080
   # (aka 127.0.0.1:6080).
-  config.vm.network :forwarded_port, guest: 6080, host: 6080
+  config.vm.network :forwarded_port, guest: 6080, host: 6080, host_ip: "127.0.0.1"
 
   # Use a shell script to "provision" the box. This installs Sandstorm using
   # the bundled installer.


### PR DESCRIPTION
On my Windows10 machine, running vagrant-spk vm up results in a stack trace. This is because I can't bind to 0.0.0.0.

Instead, forcably set it to bind to 127.0.0.1 - all the functionality, none of the issues (for me, at least!)