### PR TITLE
Better error messages when a command fails.

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -291,7 +291,13 @@ def call_vagrant_command(sandstorm_dir, *command_args):
     command = ["vagrant"]
     command.extend(command_args)
     sys.stderr.write("Calling {} in {}\n".format(" ".join(["'{}'".format(arg) for arg in command]), sandstorm_dir))
-    return subprocess.check_call(command, cwd=sandstorm_dir)
+    try:
+        return subprocess.check_call(command, cwd=sandstorm_dir)
+    except subprocess.CalledProcessError as e:
+        ANSI_RED = "\x1b[31m"
+        ANSI_RESET = "\x1b[0m"
+        msg = "Command failed with a non-zero exit status (%d)." % e.returncode
+        sys.exit(ANSI_RED + msg + ANSI_RESET)
 
 def ensure_working_vboxsf_in_base_box(sandstorm_dir):
     # If the .sandstorm/Vagrantfile refers to debian/jessie64, and does not pin it to a particular


### PR DESCRIPTION
Typically the command itself prints something reasonable, but we weren't
catching the exception, so this was obscured by a useless python stack
trace. We now catch the exception and print a concise message.