### PR TITLE
Update lesp stack for PHP 7

### DIFF
--- a/stacks/lesp/launcher.sh
+++ b/stacks/lesp/launcher.sh
@@ -2,7 +2,7 @@
 
 # Create a bunch of folders under the clean /var that php and nginx expect to exist
 mkdir -p /var/lib/nginx
-mkdir -p /var/lib/php5/sessions
+mkdir -p /var/lib/php/sessions
 mkdir -p /var/log
 mkdir -p /var/log/nginx
 # Wipe /var/run, since pidfiles and socket files from previous launches should go away
@@ -11,10 +11,10 @@ rm -rf /var/run
 mkdir -p /var/run
 
 # Spawn php
-/usr/sbin/php5-fpm --nodaemonize --fpm-config /etc/php5/fpm/php-fpm.conf &
+/usr/sbin/php-fpm7.0 --nodaemonize --fpm-config /etc/php/7.0/fpm/php-fpm.conf &
 # Wait until php has bound its socket, indicating readiness
-while [ ! -e /var/run/php5-fpm.sock ] ; do
-    echo "waiting for php5-fpm to be available at /var/run/php5-fpm.sock"
+while [ ! -e /var/run/php/php7.0-fpm.sock ] ; do
+    echo "waiting for php-fpm7.0 to be available at /var/run/php/php7.0-fpm.sock"
     sleep .2
 done
 

--- a/stacks/lesp/service-config/nginx.conf
+++ b/stacks/lesp/service-config/nginx.conf
@@ -50,7 +50,7 @@ http {
 			try_files $uri $uri/ =404;
 		}
 		location ~ \.php$ {
-			fastcgi_pass unix:/var/run/php5-fpm.sock;
+			fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 			fastcgi_index index.php;
 			fastcgi_split_path_info ^(.+\.php)(/.+)$;
 			fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/stacks/lesp/setup.sh
+++ b/stacks/lesp/setup.sh
@@ -7,24 +7,24 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y nginx php5-fpm php5-sqlite php5-cli php5-curl git php5-dev
+apt-get install -y nginx php7.0-fpm php7.0-sqlite3 php7.0-cli php7.0-curl git php7.0-dev
 service nginx stop
-service php5-fpm stop
+service php7.0-fpm stop
 systemctl disable nginx
-systemctl disable php5-fpm
-# patch /etc/php5/fpm/pool.d/www.conf to not change uid/gid to www-data
+systemctl disable php7.0-fpm
+# patch /etc/php/7.0/fpm/pool.d/www.conf to not change uid/gid to www-data
 sed --in-place='' \
         --expression='s/^listen.owner = www-data/;listen.owner = www-data/' \
         --expression='s/^listen.group = www-data/;listen.group = www-data/' \
         --expression='s/^user = www-data/;user = www-data/' \
         --expression='s/^group = www-data/;group = www-data/' \
-        /etc/php5/fpm/pool.d/www.conf
-# patch /etc/php5/fpm/php-fpm.conf to not have a pidfile
+        /etc/php/7.0/fpm/pool.d/www.conf
+# patch /etc/php/7.0/fpm/php-fpm.conf to not have a pidfile
 sed --in-place='' \
         --expression='s/^pid =/;pid =/' \
-        /etc/php5/fpm/php-fpm.conf
-# patch /etc/php5/fpm/pool.d/www.conf to no clear environment variables
+        /etc/php/7.0/fpm/php-fpm.conf
+# patch /etc/php/7.0/fpm/pool.d/www.conf to no clear environment variables
 # so we can pass in SANDSTORM=1 to apps
 sed --in-place='' \
         --expression='s/^;clear_env = no/clear_env=no/' \
-        /etc/php5/fpm/pool.d/www.conf
+        /etc/php/7.0/fpm/pool.d/www.conf


### PR DESCRIPTION
This update is **completely untested**. However, I feel it should be merged. Essentially, I mirrored @Rivierg's modifications to the lemp stack, which is probably 9/10ths of what is needed to ensure lesp also works on Debian Stretch. All package renames and location changes are identical to the changes in #211, except for php7.0-sqlite3, which I had to look up the name of, since they added the SQLite version to the package name according to https://packages.debian.org/stretch/php7.0-sqlite3