### PR TITLE
Fix Vagrantfile for 2.0.3+

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -59,7 +59,9 @@ VM_NAME = File.basename(File.dirname(File.dirname(__FILE__))) + "_sandstorm_#{Ti
 VAGRANTFILE_API_VERSION = "2"
 
 # ugly hack to prevent hashicorp's bitrot. See https://github.com/hashicorp/vagrant/issues/9442
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+unless Vagrant::DEFAULT_SERVER_URL.frozen?
+  Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base on the Sandstorm snapshots of the official Debian 8 (jessie) box.


### PR DESCRIPTION
With Vagrant 2.0.3 and up, the DEFAULT_SERVER_URL is frozen, so it cannot be changed. But earlier versions of Vagrant need this line to work. While we could mandate a minimum Vagrant version, this change would set the correct URL if it's wrong, and leave it alone if the Vagrant version is new enough not to need it.

Corrects this error:

> There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

> Path: [removed]\Vagrantfile
Line number: 13
Message: RuntimeError: can't modify frozen String

In https://github.com/hashicorp/vagrant/issues/9442 this fix was posted by @reedy, credit where credit is due.