### PR TITLE
Fix LEMP stack, install MySQL

### DIFF
--- a/stacks/lemp/launcher.sh
+++ b/stacks/lemp/launcher.sh
@@ -21,7 +21,7 @@ mkdir -p /var/run/mysqld
 HOME=/etc/mysql /usr/sbin/mysqld --initialize
 
 # Spawn mysqld, php
-HOME=/etc/mysql /usr/sbin/mysqld &
+HOME=/etc/mysql /usr/sbin/mysqld --skip-grant-tables &
 /usr/sbin/php-fpm7.0 --nodaemonize --fpm-config /etc/php/7.0/fpm/php-fpm.conf &
 # Wait until mysql and php have bound their sockets, indicating readiness
 while [ ! -e /var/run/mysqld/mysqld.sock ] ; do

--- a/stacks/lemp/launcher.sh
+++ b/stacks/lemp/launcher.sh
@@ -2,6 +2,7 @@
 
 # Create a bunch of folders under the clean /var that php, nginx, and mysql expect to exist
 mkdir -p /var/lib/mysql
+mkdir -p /var/lib/mysql-files
 mkdir -p /var/lib/nginx
 mkdir -p /var/lib/php/sessions
 mkdir -p /var/log
@@ -10,13 +11,14 @@ mkdir -p /var/log/nginx
 # Wipe /var/run, since pidfiles and socket files from previous launches should go away
 # TODO someday: I'd prefer a tmpfs for these.
 rm -rf /var/run
-mkdir -p /var/run
+mkdir -p /var/run/php
 rm -rf /var/tmp
 mkdir -p /var/tmp
 mkdir -p /var/run/mysqld
 
 # Ensure mysql tables created
-HOME=/etc/mysql /usr/bin/mysql_install_db --force
+# HOME=/etc/mysql /usr/bin/mysql_install_db
+HOME=/etc/mysql /usr/sbin/mysqld --initialize
 
 # Spawn mysqld, php
 HOME=/etc/mysql /usr/sbin/mysqld &

--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -6,6 +6,11 @@
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
+
+echo -e "deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ stretch mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql
+apt-key add /tmp/RPM-GPG-KEY-mysql
+
 apt-get update
 apt-get install -y nginx php7.0-fpm php7.0-mysql php7.0-cli php7.0-curl git php7.0-dev mysql-server
 service nginx stop
@@ -25,6 +30,10 @@ sed --in-place='' \
 sed --in-place='' \
         --expression='s/^pid =/;pid =/' \
         /etc/php/7.0/fpm/php-fpm.conf
+# patch /etc/php/7.0/fpm/php-fpm.conf to place the sock file in /var 
+sed --in-place='' \
+       --expression='s/^listen = \/run\/php\/php7.0-fpm.sock/listen = \/var\/run\/php\/php7.0-fpm.sock/' \
+        /etc/php/7.0/fpm/pool.d/www.conf
 # patch /etc/php/7.0/fpm/pool.d/www.conf to no clear environment variables
 # so we can pass in SANDSTORM=1 to apps
 sed --in-place='' \


### PR DESCRIPTION
So Debian Stretch installs MariaDB instead of MySQL. That breaks vagrant-spk, so for now, this adds repo.mysql.com as an apt source and gets MySQL proper. MySQL expected an additional directory in var (seems to to `secure_file_priv`), and indicated that the old way of initalizing the database was deprecated, so we're going to try changing that too.

Additionally, this fixes PHP 7's sock file location as with the update-lesp patch.

Fixes #220.