### PR TITLE
Update version number in Windows installer

### DIFF
--- a/windows-support/windows-installer.iss
+++ b/windows-support/windows-installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "vagrant-spk"
-#define MyAppVersion "2015-07-24"
+#define MyAppVersion "v0.233"
 #define MyAppPublisher "Sandstorm Development Group, Inc."
 #define MyAppURL "https://docs.sandstorm.io/"
 #define MyAppExeName "vagrant-spk.exe"


### PR DESCRIPTION
Set for next Sandstorm release version (somewhat optimistically). But either way it'll be more accurate than a date in 2015, and give some clear indication if a user has installed a modern vagrant-spk.

Fixes #208.