### PR TITLE
Update copyright to SDG

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2015 Sandstorm Development Group, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2.7
-#   Copyright 2015 Drew Fisher (zarvox@zarvox.org)
+#   Copyright 2015 Sandstorm Development Group, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.


### PR DESCRIPTION
AFAIK, it should be?

The original license file and copyright text hasn't been modified since prior to the project being moved into the sandstorm-io organization.