### PR TITLE
Add vagrant-spk --version

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -22,6 +22,9 @@
 
 from __future__ import print_function
 
+# TODO(someday): Increment version number and commit as part of release.sh
+__version__ = "v0.233"
+
 import argparse
 import os
 import glob
@@ -970,6 +973,7 @@ def main():
     parser = argparse.ArgumentParser(prog=sys.argv[0], formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("command", choices=[c.name for c in operations], help=ops_helptext)
     parser.add_argument("command_specific_args", nargs="*")
+    parser.add_argument("-V", "--version", action="version", version="vagrant-spk "+__version__)
     parser.add_argument(
         "--work-directory",
         action='store',


### PR DESCRIPTION
Fixes #180 in a way that Stack Overflow say is fairly standard. I've had issues in the past with multiple vagrant-spks on a box and not knowing which I just ran, so I personally would find this quite helpful.

In a future world, I'd perhaps like the release.sh script to edit this value (and the similar one in #223) and make a commit. But vagrant-spk releases are fairly infrequent, so my hope is this is adequate enough for now.