### PR TITLE
Update uwsgi stack for Stretch

### DIFF
--- a/stacks/uwsgi/launcher.sh
+++ b/stacks/uwsgi/launcher.sh
@@ -17,10 +17,11 @@ mkdir -p /var/run/mysqld
 UWSGI_SOCKET_FILE=/var/run/uwsgi.sock
 
 # Ensure mysql tables created
-HOME=/etc/mysql /usr/bin/mysql_install_db --force
+# HOME=/etc/mysql /usr/bin/mysql_install_db
+HOME=/etc/mysql /usr/sbin/mysqld --initialize
 
 # Spawn mysqld
-HOME=/etc/mysql /usr/sbin/mysqld &
+HOME=/etc/mysql /usr/sbin/mysqld --skip-grant-tables &
 
 MYSQL_SOCKET_FILE=/var/run/mysqld/mysqld.sock
 # Wait for mysql to bind its socket

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -6,6 +6,11 @@
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
+
+echo -e "deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ stretch mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql
+apt-key add /tmp/RPM-GPG-KEY-mysql
+
 apt-get update
 apt-get install -y nginx mysql-server libmysqlclient-dev uwsgi uwsgi-plugin-python build-essential python-dev python-virtualenv git
 # patch mysql conf to not change uid, and to use /var/tmp over /tmp


### PR DESCRIPTION
This PR isn't complete yet, but is currently "better than what currently happens". It updates the MySQL install behavior from my PHP PR (#222), so that we don't install MariaDB.

Current issue using python test app:

> /opt/app/env exists, moving on
/opt/app/.sandstorm/build.sh: line 11: /opt/app/env/bin/pip: No such file or directory
Connection to 127.0.0.1 closed.
[31mCommand failed with a non-zero exit status (127).[0m

I suspect pip needs to be installed somehow, as it is indeed not in /opt/app/env/bin.
