### PR TITLE
UWSGI: Missing directory in launcher.sh

### DIFF
--- a/stacks/uwsgi/launcher.sh
+++ b/stacks/uwsgi/launcher.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 # something something folders
 mkdir -p /var/lib/mysql
+mkdir -p /var/lib/mysql-files
 mkdir -p /var/lib/nginx
 mkdir -p /var/log
 mkdir -p /var/log/mysql


### PR DESCRIPTION
To match lemp stack, and with this change, the python test app works. No idea why I was having difficulty before, because this wasn't the only thing missing.