### PR TITLE
Update Go stack

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -8,10 +8,10 @@ set -euo pipefail
 # The version of golang in the main repo is *ancient* (1.3.x); let's get
 # ourselves a newer version:
 
-echo 'deb http://httpredir.debian.org/debian/ jessie-backports main' >> \
+echo 'deb http://httpredir.debian.org/debian/ stretch-backports main' >> \
 	/etc/apt/sources.list.d/backports.list
 apt-get update
-apt-get -t jessie-backports install -y golang
+apt-get -t stretch-backports install -y golang
 
 # Needed for fetching most dependencies:
 apt-get install -y git


### PR DESCRIPTION
Fixes #232. (I think)

Can confirm this change causes it to install golang-1.10, but don't have anything to test against handy.