### PR TITLE
Bump versions for 0.236 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+### v0.236 (2018-07-08)
+- Updated multiple stacks for compatibility with Debian stretch.
+- Added `listkeys` command to show which app keys are in your keyring.
+- Added ability to check vagrant-spk version with `--version`.
+- Fix bug where `curl` cannot be downloaded.
+- Fix bug caused by Vagrant version 2.0.3 and later.
+
 ### v0.230 (2018-03-17)
 - Now using Debian Contrib base image rather than a custom image.
 - Fixed various bitrot.
 - Other fixes, see git history.
 
 ### v0.186 (2016-09-21)
-
 - BUG FIX:
   - All stacks embedding MySQL now use `/var/tmp` for temporary storage. Thanks
     @FiloSottile for reporting a Piwik issue that enabled us to notice this problem

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -23,7 +23,7 @@
 from __future__ import print_function
 
 # TODO(someday): Increment version number and commit as part of release.sh
-__version__ = "v0.233"
+__version__ = "v0.236"
 
 import argparse
 import os

--- a/windows-support/windows-installer.iss
+++ b/windows-support/windows-installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "vagrant-spk"
-#define MyAppVersion "v0.233"
+#define MyAppVersion "v0.236"
 #define MyAppPublisher "Sandstorm Development Group, Inc."
 #define MyAppURL "https://docs.sandstorm.io/"
 #define MyAppExeName "vagrant-spk.exe"


### PR DESCRIPTION
This includes the changelog for everything since 0.230.