### PR TITLE
Fixed mingw total ram calculation command

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -113,7 +113,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # powershell may not be available on Windows XP and Vista, so wrap this in a rescue block
     begin
       cpus = `powershell -Command "(Get-WmiObject Win32_Processor -Property NumberOfLogicalProcessors | Select-Object -Property NumberOfLogicalProcessors | Measure-Object NumberOfLogicalProcessors -Sum).Sum"`.to_i
-      total_kB_ram = `powershell -Command "Get-CimInstance -class cim_physicalmemory | % $_.Capacity}"`.to_i / 1024
+      total_kB_ram = `powershell -Command "Get-CimInstance -class cim_physicalmemory | % $_.Capacity"`.to_i / 1024
     rescue
     end
   end


### PR DESCRIPTION
Removed an extra "}" from the command