### PR TITLE
Fix lookup of total memory on Windows machines

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -113,7 +113,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # powershell may not be available on Windows XP and Vista, so wrap this in a rescue block
     begin
       cpus = `powershell -Command "(Get-WmiObject Win32_Processor -Property NumberOfLogicalProcessors | Select-Object -Property NumberOfLogicalProcessors | Measure-Object NumberOfLogicalProcessors -Sum).Sum"`.to_i
-      total_kB_ram = `powershell -Command "Get-CimInstance -class cim_physicalmemory | % $_.Capacity}"`.to_i / 1024
+      total_kB_ram = `powershell -Command "[math]::Round((Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory)"`.to_i / 1024
     rescue
     end
   end


### PR DESCRIPTION
Credit where credit's due, this problem was discovered by @spollard and the related analysis is in #240. However, none of the versions of the old command returned a single integer representing the total RAM. Either no result was returned or two results, each containing half the RAM, was returned as a table. This alternative returns a single integer value for the total system memory, and should actually work here.

When @zarvox wrote this, he wrapped it in a rescue block to handle computers without PowerShell, but my guess is that this conveniently also caused it not to fail when his PowerShell was not returning valid responses as well.

Closes #240.