### PR TITLE
Remove rescue block from Windows RAM calculation

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -110,12 +110,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cpus = `nproc`.to_i
     total_kB_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
   elsif host =~ /mingw/
-    # powershell may not be available on Windows XP and Vista, so wrap this in a rescue block
-    begin
-      cpus = `powershell -Command "(Get-WmiObject Win32_Processor -Property NumberOfLogicalProcessors | Select-Object -Property NumberOfLogicalProcessors | Measure-Object NumberOfLogicalProcessors -Sum).Sum"`.to_i
-      total_kB_ram = `powershell -Command "[math]::Round((Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory)"`.to_i / 1024
-    rescue
-    end
+    cpus = `powershell -Command "(Get-WmiObject Win32_Processor -Property NumberOfLogicalProcessors | Select-Object -Property NumberOfLogicalProcessors | Measure-Object NumberOfLogicalProcessors -Sum).Sum"`.to_i
+    total_kB_ram = `powershell -Command "[math]::Round((Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory)"`.to_i / 1024
   end
   # Use the same number of CPUs within Vagrant as the system, with 1
   # as a default.


### PR DESCRIPTION
Effectively drops support for Windows XP/Vista from vagrant-spk, but fixes an issue where broken code here does not error out and simply fails silently.