### PR TITLE
WIP: Verify all version numbers (DO NOT MERGE)

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -51,6 +51,26 @@ function assert_changelog_present() {
   fi
 }
 
+function assert_version_updated() {
+  # Verify that the vagrant-spk version has been updated.
+  EXPECTED_SCRIPT_VERSION="__version__ = \"$TAG_NAME\""
+  if [ "$(head -n 26 vagrant-spk | tail -n 1)" != "$EXPECTED_SCRIPT_VERSION" ]; then
+    echo "vagrant-spk version not updated. 26th line should be:" >&2
+    echo "$EXPECTED_SCRIPT_VERSION" >&2
+    exit 1
+  fi
+}
+
+function assert_winstall_updated() {
+  # Verify that the Windows installer version has been updated.
+  EXPECTED_WINSTALL_VERSION="#define MyAppVersion \"$TAG_NAME\""
+  if [ "$(head -n 5 windows-support/windows-installer.iss | tail -n 1)" != "$EXPECTED_WINSTALL_VERSION" ]; then
+    echo "Windows installer version not updated. 5th line should be:" >&2
+    echo "$EXPECTED_WINSTALL_VERSION" >&2
+    exit 1
+  fi
+}
+
 function build_windows_exe() {
   # The Windows EXE filename is always vagrant-spk-setup.exe locally, and when we upload it to
   # GitHub as a release artifact, we rename it to use $TAG_NAME in the filename to indicate the
@@ -101,6 +121,8 @@ function main() {
   assert_git_state_is_clean
   get_release_name
   assert_changelog_present
+  assert_version_updated
+  assert_winstall_updated
   build_windows_exe
   tag_and_push
   create_github_release


### PR DESCRIPTION
Checks the version number in the script itself and the Windows install configuration.

I've tested each one prior to updating the version number at the location in question and after to verify that it fails/passes each check correctly respectively. It is very sad if we push a release which reports the wrong version either when checked by command (vagrant-spk --version) or in the Windows installer, and it has happened before.

This method is a little bit fragile in that it picks a precise line number that it should be on, and if we amend the top of either file we may need to fix this, but there is not much functional code above either line, so I suspect this will not be a frequent problem. It should be good enough for now.