### PR TITLE
Add server link

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -74,6 +74,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base on the Sandstorm snapshots of the official Debian 9 (stretch) box with vboxsf support.
   config.vm.box = "debian/contrib-stretch64"
   config.vm.box_version = "9.3.0"
+  config.vm.post_up_message = "Your virtual server is running at http://local.sandstorm.io:6080."
+
 
   if Vagrant.has_plugin?("vagrant-vbguest") then
     # vagrant-vbguest is a Vagrant plugin that upgrades

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -74,7 +74,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base on the Sandstorm snapshots of the official Debian 9 (stretch) box with vboxsf support.
   config.vm.box = "debian/contrib-stretch64"
   config.vm.box_version = "9.3.0"
-  config.vm.post_up_message = "Your virtual server is running at http://local.sandstorm.io:6080."
+  config.vm.post_up_message = "Your virtual server is running at http://local.sandstorm.io:6090."
 
 
   if Vagrant.has_plugin?("vagrant-vbguest") then


### PR DESCRIPTION
Add a link to the server launched on when using the command "vagrant-spk vm up." This makes it easier to launch Sandstorm in the browser without rechecking the documentation.