### PR TITLE
Unpin box and apt upgrade

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -73,7 +73,6 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base on the Sandstorm snapshots of the official Debian 9 (stretch) box with vboxsf support.
   config.vm.box = "debian/contrib-stretch64"
-  config.vm.box_version = "9.3.0"
   config.vm.post_up_message = "Your virtual server is running at http://local.sandstorm.io:6090."
 
 
@@ -191,8 +190,12 @@ CURL_OPTS="--silent --show-error"
 echo localhost > /etc/hostname
 hostname localhost
 
-# Install curl that is needed below.
+# Grub updates don't silent install well
+apt-mark hold grub-pc
 apt-get update
+apt-get upgrade -y
+
+# Install curl that is needed below.
 apt-get install -y curl
 
 # The following line copies stderr through stderr to cat without accidentally leaving it in the


### PR DESCRIPTION
Fixes #248 

I tested this with diy stack and the VM came up alright. I'll probably do a wholesome test with the Python test app before I merge it. I found grub-pc held up apt-get upgrade, and from a Sandstorm package building standpoint, we hardly care if grub is up to date on the VM, so I held it.

Note that we should document `vagrant-spk vm box update` somewhere for people who currently use vagrant-spk and have the old box downloaded already. But realistically this change should mostly update your box up to the same level anyways.