### PR TITLE
Update the 'golang' stack.

### DIFF
--- a/stacks/golang/build.sh
+++ b/stacks/golang/build.sh
@@ -7,6 +7,8 @@ if [ ! -e go.mod ]; then
 	printf "vagrant-spk's golang stack does not support older GOPATH\n"
 	printf "based projects. Try running:\n" >&2
 	printf "\n" >&2
+	printf "    vagrant-spk vm ssh\n" >&2
+	printf "    cd /opt/app\n" >&2
 	printf "    go mod init example.com/mypkg\n" >&2
 	exit 1
 fi

--- a/stacks/golang/build.sh
+++ b/stacks/golang/build.sh
@@ -1,19 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-# In order to import other packages in your own source tree, you'll have to
-# set this to the import url for the root of your repository. for example:
-#
-# pkgpath=github.com/me/my-apps-repo
-pkgpath=
-
-export GOPATH=$HOME/go
-
-if [ -n "$pkgpath" ] && [ ! -L "$GOPATH/src/$pkgpath" ] ; then
-	ln -s /opt/app "$GOPATH/src/$pkgpath"
-fi
-
 cd /opt/app
-go get -v -d ./...
-go build -v -i
+if [ ! -e go.mod ]; then
+	printf "Error: This directory does not contain a go module;\n"
+	printf "vagrant-spk's golang stack does not support older GOPATH\n"
+	printf "based projects. Try running:\n" >&2
+	printf "\n" >&2
+	printf "    go mod init example.com/mypkg\n" >&2
+	exit 1
+fi
+go build -o app
 exit 0

--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -5,15 +5,18 @@
 
 set -euo pipefail
 
-# The version of golang in the main repo is *ancient* (1.3.x); let's get
-# ourselves a newer version:
+version=1.15
+os=linux
+arch=amd64
 
-echo 'deb http://httpredir.debian.org/debian/ stretch-backports main' >> \
-	/etc/apt/sources.list.d/backports.list
-apt-get update
-apt-get -t stretch-backports install -y golang
+# The version of golang in the debian repositories tends to be incredibly
+# out of date; let's get ourselves a newer version from upstream:
+curl -L https://golang.org/dl/go${version}.${os}-${arch}.tar.gz -o go.tar.gz
+tar -C /usr/local -xzf go.tar.gz
+rm go.tar.gz
+echo 'export PATH=/usr/local/go/bin:$PATH' > /etc/profile.d/go.sh
 
-# Needed for fetching most dependencies:
+# Needed for fetching go libraries:
 apt-get install -y git
 
 exit 0


### PR DESCRIPTION
Uses the latest version of the toolchain, and supports (only) Go
modules.