### PR TITLE
Make vagrant-spk use new CSP when creating VMs

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -223,6 +223,10 @@ usermod -a -G 'sandstorm' 'vagrant'
 sudo sed --in-place='' \
         --expression='s/^BIND_IP=.*/BIND_IP=0.0.0.0/' \
         /opt/sandstorm/sandstorm.conf
+
+# Force vagrant-spk to use the strict CSP, see sandstorm#3424 for details.
+echo 'ALLOW_LEGACY_RELAXED_CSP=false' >> /opt/sandstorm/sandstorm.conf
+
 sudo service sandstorm restart
 # Enable apt-cacher-ng proxy to make things faster if one appears to be running on the gateway IP
 GATEWAY_IP=$(ip route  | grep ^default  | cut -d ' ' -f 3)


### PR DESCRIPTION
I've tested this change on ShareLatex on my Windows machine: It does indeed cause the vagrant-spk VM to use the correct config option. I placed it by another sandstorm.conf modification just prior to restarting the Sandstorm service, which seemed like a good spot.

This is to ensure new apps and app updates can easily be tested against sandstorm-io/sandstorm#3409. Track our progress on concluding this project at sandstorm-io/sandstorm#3424

vagrant-spk users should be using the latest commit of vagrant-spk, and may need to `vagrant-spk vm destroy`, `vagrant-spk upgradevm`, and then `vagrant-spk vm up` to take advantage of this for existing dev environments.