### PR TITLE
Bump the golang stack's version number.

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-version=1.15
+version=1.15.1
 os=linux
 arch=amd64
 


### PR DESCRIPTION
Upstream just pushed out a patch release today, which fixes a security
vulnerability (I do not believe it affects anything that currently runs
in sandstorm).