### PR TITLE
First draft of switching to gh tool

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,7 +8,7 @@ function assert_github_token_and_release_tool_present() {
   export | grep -q GITHUB_TOKEN= || (echo "Aiee, you should set a GITHUB_TOKEN environment variable." ; exit 1)
 
   echo "**** Checking path for GitHub release tool. ****"
-  which github-release >/dev/null || (echo "Aiee, you need a github-release tool in the PATH."; exit 1)
+  which gh >/dev/null || (echo "Aiee, you need a gh tool in the PATH."; exit 1)
 }
 
 function assert_git_state_is_clean() {
@@ -91,8 +91,7 @@ function create_github_release() {
     echo "Not creating GitHub release yet. Re-run with DRY_RUN=no in the environment."
     echo ""
   else
-    github-release release --draft --tag "$TAG_NAME" -u sandstorm-io -r vagrant-spk -d "$(python -c 's = open("CHANGELOG.md").read(); print s[:s.index("\n### ")-1]')"
-    github-release upload -u sandstorm-io -r vagrant-spk -t "$TAG_NAME" -n "vagrant-spk-setup-$TAG_NAME.exe" --file "$WINDOWS_EXE"
+    gh release create "$TAG_NAME" "$WINDOWS_EXE" -d -R sandstorm-io/vagrant-spk -n "$(python -c 's = open("CHANGELOG.md").read(); print s[:s.index("\n### ")-1]')"
   fi
 }
 

--- a/release.sh
+++ b/release.sh
@@ -91,7 +91,8 @@ function create_github_release() {
     echo "Not creating GitHub release yet. Re-run with DRY_RUN=no in the environment."
     echo ""
   else
-    gh release create "$TAG_NAME" "$WINDOWS_EXE" -d -R sandstorm-io/vagrant-spk -n "$(python -c 's = open("CHANGELOG.md").read(); print s[:s.index("\n### ")-1]')"
+    mv "$WINDOWS_EXE" "vagrant-spk-setup-$TAG_NAME.exe"
+    gh release create "$TAG_NAME" "vagrant-spk-setup-$TAG_NAME.exe" -d -R sandstorm-io/vagrant-spk -n "$(python -c 's = open("CHANGELOG.md").read(); print s[:s.index("\n### ")-1]')"
   fi
 }
 


### PR DESCRIPTION
This is definitely a draft, I haven't tested it, but made this based on https://cli.github.com/manual/gh_release_create and what's already in this script. #256 documents many other pain points I had running the release script before.

`gh` recently added the ability to create releases, and it's *fairly similar* to github-release. It looks like it supports the GITHUB_TOKEN method of authentication too, so I left that part of the script alone.

The only thing I am aware of that this won't do correctly, is rename the EXE file uploaded to include the tag name, as seen in the artifacts here: https://github.com/sandstorm-io/vagrant-spk/releases because the gh release script doesn't appear to have any support for setting a filename separate from the actual file you upload from a glance. The solution presumably is to rename the file before we upload it.