### PR TITLE
Bump golang stack version.

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-version=1.15.4
+version=1.15.5
 os=linux
 arch=amd64
 


### PR DESCRIPTION
This release includes security fixes for a number of standard library
functions which previously would panic under various circumstances,
potentially allowing denial-of-service attacks.