### PR TITLE
Bump golang version.

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-version=1.15.6
+version=1.15.7
 os=linux
 arch=amd64
 


### PR DESCRIPTION
Security fix (arbitrary code execution at build-time) -- though the Go
devs are in the minority in even considering that a vulnerability; most
package managers allow this as a fundamental architectural choice :/