### PR TITLE
Golang stack: bump toolchain version.

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-version=1.15.8
+version=1.16
 os=linux
 arch=amd64
 


### PR DESCRIPTION
This is a feature release; it includes changes to standard library and
tooling, though they are backwards compatible, so we still only need
to bump the version number.