### PR TITLE
Use latest meteor-spk in Meteor stack

### DIFF
--- a/stacks/meteor/setup.sh
+++ b/stacks/meteor/setup.sh
@@ -12,7 +12,7 @@ apt-get install -y build-essential git
 cd /opt/
 
 NODE_ENV=production
-PACKAGE=meteor-spk-0.4.1
+PACKAGE=meteor-spk-0.5.1
 PACKAGE_FILENAME="$PACKAGE.tar.xz"
 CACHE_TARGET="/host-dot-sandstorm/caches/${PACKAGE_FILENAME}"
 
@@ -39,7 +39,7 @@ cp -a /lib/x86_64-linux-gnu/libtinfo.so.* /opt/meteor-spk/meteor-spk.deps/lib/x8
 # Unfortunately, Meteor does not explicitly make it easy to cache packages, but
 # we know experimentally that the package is mostly directly extractable to a
 # user's $HOME/.meteor directory.
-METEOR_RELEASE=1.6.1.1
+METEOR_RELEASE=1.10.1
 METEOR_PLATFORM=os.linux.x86_64
 METEOR_TARBALL_FILENAME="meteor-bootstrap-${METEOR_PLATFORM}.tar.gz"
 METEOR_TARBALL_URL="https://d3sqy0vbqsdhku.cloudfront.net/packages-bootstrap/${METEOR_RELEASE}/${METEOR_TARBALL_FILENAME}"


### PR DESCRIPTION
I haven't tested this, but on manual review, this looks like the only places this would need to be updated? I did check that the Cloudfront URL was still accurate for the Meteor download and such as well. Presumably we should have meteor-spk updated to 2.x at some point and then update this again.