### PR TITLE
Update base box to Debian Buster

### DIFF
--- a/stacks/lemp/launcher.sh
+++ b/stacks/lemp/launcher.sh
@@ -22,14 +22,14 @@ HOME=/etc/mysql /usr/sbin/mysqld --initialize
 
 # Spawn mysqld, php
 HOME=/etc/mysql /usr/sbin/mysqld --skip-grant-tables &
-/usr/sbin/php-fpm7.0 --nodaemonize --fpm-config /etc/php/7.0/fpm/php-fpm.conf &
+/usr/sbin/php-fpm7.3 --nodaemonize --fpm-config /etc/php/7.3/fpm/php-fpm.conf &
 # Wait until mysql and php have bound their sockets, indicating readiness
 while [ ! -e /var/run/mysqld/mysqld.sock ] ; do
     echo "waiting for mysql to be available at /var/run/mysqld/mysqld.sock"
     sleep .2
 done
-while [ ! -e /var/run/php/php7.0-fpm.sock ] ; do
-    echo "waiting for php-fpm7.0 to be available at /var/run/php/php7.0-fpm.sock"
+while [ ! -e /var/run/php/php7.3-fpm.sock ] ; do
+    echo "waiting for php-fpm7.3 to be available at /var/run/php/php7.3-fpm.sock"
     sleep .2
 done
 

--- a/stacks/lemp/service-config/nginx.conf
+++ b/stacks/lemp/service-config/nginx.conf
@@ -50,7 +50,7 @@ http {
 			try_files $uri $uri/ =404;
 		}
 		location ~ \.php$ {
-			fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+			fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
 			fastcgi_index index.php;
 			fastcgi_split_path_info ^(.+\.php)(/.+)$;
 			fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -7,38 +7,38 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo -e "deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ stretch mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+echo -e "deb http://repo.mysql.com/apt/debian/ buster mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
 wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql
 apt-key add /tmp/RPM-GPG-KEY-mysql
 
 apt-get update
-apt-get install -y nginx php7.0-fpm php7.0-mysql php7.0-cli php7.0-curl git php7.0-dev mysql-server
+apt-get install -y nginx php-fpm php-mysql php-cli php-curl git php-dev mysql-server
 service nginx stop
-service php7.0-fpm stop
+service php7.3-fpm stop
 service mysql stop
 systemctl disable nginx
-systemctl disable php7.0-fpm
+systemctl disable php7.3-fpm
 systemctl disable mysql
-# patch /etc/php/7.0/fpm/pool.d/www.conf to not change uid/gid to www-data
+# patch /etc/php/7.3/fpm/pool.d/www.conf to not change uid/gid to www-data
 sed --in-place='' \
         --expression='s/^listen.owner = www-data/;listen.owner = www-data/' \
         --expression='s/^listen.group = www-data/;listen.group = www-data/' \
         --expression='s/^user = www-data/;user = www-data/' \
         --expression='s/^group = www-data/;group = www-data/' \
-        /etc/php/7.0/fpm/pool.d/www.conf
-# patch /etc/php/7.0/fpm/php-fpm.conf to not have a pidfile
+        /etc/php/7.3/fpm/pool.d/www.conf
+# patch /etc/php/7.3/fpm/php-fpm.conf to not have a pidfile
 sed --in-place='' \
         --expression='s/^pid =/;pid =/' \
-        /etc/php/7.0/fpm/php-fpm.conf
-# patch /etc/php/7.0/fpm/php-fpm.conf to place the sock file in /var 
+        /etc/php/7.3/fpm/php-fpm.conf
+# patch /etc/php/7.3/fpm/php-fpm.conf to place the sock file in /var 
 sed --in-place='' \
-       --expression='s/^listen = \/run\/php\/php7.0-fpm.sock/listen = \/var\/run\/php\/php7.0-fpm.sock/' \
-        /etc/php/7.0/fpm/pool.d/www.conf
-# patch /etc/php/7.0/fpm/pool.d/www.conf to no clear environment variables
+       --expression='s/^listen = \/run\/php\/php7.3-fpm.sock/listen = \/var\/run\/php\/php7.3-fpm.sock/' \
+        /etc/php/7.3/fpm/pool.d/www.conf
+# patch /etc/php/7.3/fpm/pool.d/www.conf to no clear environment variables
 # so we can pass in SANDSTORM=1 to apps
 sed --in-place='' \
         --expression='s/^;clear_env = no/clear_env=no/' \
-        /etc/php/7.0/fpm/pool.d/www.conf
+        /etc/php/7.3/fpm/pool.d/www.conf
 # patch mysql conf to not change uid, and to use /var/tmp over /tmp
 # for secure-file-priv see https://github.com/sandstorm-io/vagrant-spk/issues/195
 sed --in-place='' \

--- a/stacks/lesp/launcher.sh
+++ b/stacks/lesp/launcher.sh
@@ -11,10 +11,10 @@ rm -rf /var/run
 mkdir -p /var/run/php
 
 # Spawn php
-/usr/sbin/php-fpm7.0 --nodaemonize --fpm-config /etc/php/7.0/fpm/php-fpm.conf &
+/usr/sbin/php-fpm7.3 --nodaemonize --fpm-config /etc/php/7.3/fpm/php-fpm.conf &
 # Wait until php has bound its socket, indicating readiness
-while [ ! -e /var/run/php/php7.0-fpm.sock ] ; do
-    echo "waiting for php-fpm7.0 to be available at /var/run/php/php7.0-fpm.sock"
+while [ ! -e /var/run/php/php7.3-fpm.sock ] ; do
+    echo "waiting for php-fpm7.3 to be available at /var/run/php/php7.3-fpm.sock"
     sleep .2
 done
 

--- a/stacks/lesp/service-config/nginx.conf
+++ b/stacks/lesp/service-config/nginx.conf
@@ -50,7 +50,7 @@ http {
 			try_files $uri $uri/ =404;
 		}
 		location ~ \.php$ {
-			fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+			fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
 			fastcgi_index index.php;
 			fastcgi_split_path_info ^(.+\.php)(/.+)$;
 			fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/stacks/lesp/setup.sh
+++ b/stacks/lesp/setup.sh
@@ -7,28 +7,28 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y nginx php7.0-fpm php7.0-sqlite3 php7.0-cli php7.0-curl git php7.0-dev
+apt-get install -y nginx php-fpm php-sqlite3 php-cli php-curl git php-dev
 service nginx stop
-service php7.0-fpm stop
+service php7.3-fpm stop
 systemctl disable nginx
-systemctl disable php7.0-fpm
-# patch /etc/php/7.0/fpm/pool.d/www.conf to not change uid/gid to www-data
+systemctl disable php7.3-fpm
+# patch /etc/php/7.3/fpm/pool.d/www.conf to not change uid/gid to www-data
 sed --in-place='' \
         --expression='s/^listen.owner = www-data/;listen.owner = www-data/' \
         --expression='s/^listen.group = www-data/;listen.group = www-data/' \
         --expression='s/^user = www-data/;user = www-data/' \
         --expression='s/^group = www-data/;group = www-data/' \
-        /etc/php/7.0/fpm/pool.d/www.conf
-# patch /etc/php/7.0/fpm/php-fpm.conf to not have a pidfile
+        /etc/php/7.3/fpm/pool.d/www.conf
+# patch /etc/php/7.3/fpm/php-fpm.conf to not have a pidfile
 sed --in-place='' \
         --expression='s/^pid =/;pid =/' \
-        /etc/php/7.0/fpm/php-fpm.conf
-# patch /etc/php/7.0/fpm/php-fpm.conf to place the sock file in /var
+        /etc/php/7.3/fpm/php-fpm.conf
+# patch /etc/php/7.3/fpm/php-fpm.conf to place the sock file in /var
 sed --in-place='' \
-       --expression='s/^listen = \/run\/php\/php7.0-fpm.sock/listen = \/var\/run\/php\/php7.0-fpm.sock/' \
-       /etc/php/7.0/fpm/pool.d/www.conf
-# patch /etc/php/7.0/fpm/pool.d/www.conf to no clear environment variables
+       --expression='s/^listen = \/run\/php\/php7.3-fpm.sock/listen = \/var\/run\/php\/php7.3-fpm.sock/' \
+       /etc/php/7.3/fpm/pool.d/www.conf
+# patch /etc/php/7.3/fpm/pool.d/www.conf to no clear environment variables
 # so we can pass in SANDSTORM=1 to apps
 sed --in-place='' \
         --expression='s/^;clear_env = no/clear_env=no/' \
-        /etc/php/7.0/fpm/pool.d/www.conf
+        /etc/php/7.3/fpm/pool.d/www.conf

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo -e "deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ stretch mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+echo -e "deb http://repo.mysql.com/apt/debian/ buster mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
 wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql
 apt-key add /tmp/RPM-GPG-KEY-mysql
 

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -72,7 +72,7 @@ end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base on the Sandstorm snapshots of the official Debian 9 (stretch) box with vboxsf support.
-  config.vm.box = "debian/contrib-stretch64"
+  config.vm.box = "debian/contrib-buster64"
   config.vm.post_up_message = "Your virtual server is running at http://local.sandstorm.io:6090."
 
 


### PR DESCRIPTION
I absolutely still need to test/validate this PR. :) But it addresses #250 in theory. I believe we can safely replace packages like php-fpm7.3 with php-fpm, as the latter depends on the former and we want to use the default version a given Debian release uses. Ideally, I need to figure out how to avoid so many version-specific references so switching boxes is not painful.