### PR TITLE
Release script pulls version from vagrant-spk

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -34,11 +34,12 @@ function assert_git_state_is_clean() {
 }
 
 function get_release_name() {
-  # DISPLAY_VERSION gets used in the git tag description
-  DISPLAY_VERSION='1.0'
-
   # TAG_NAME gets used as the git tag name
-  TAG_NAME="v${DISPLAY_VERSION}"
+  TAG_NAME="$(./vagrant-spk --version)"
+  TAG_NAME="${TAG_NAME:12}"
+
+  # DISPLAY_VERSION gets used in the git tag description
+  DISPLAY_VERSION="${TAG_NAME:1}"
 }
 
 function assert_changelog_present() {

--- a/release.sh
+++ b/release.sh
@@ -35,8 +35,7 @@ function assert_git_state_is_clean() {
 
 function get_release_name() {
   # TAG_NAME gets used as the git tag name
-  TAG_NAME="$(./vagrant-spk --version)"
-  TAG_NAME="${TAG_NAME:12}"
+  TAG_NAME="$(./vagrant-spk --version | awk '{print $2}')"
 
   # DISPLAY_VERSION gets used in the git tag description
   DISPLAY_VERSION="${TAG_NAME:1}"


### PR DESCRIPTION
In review of #262, @zenhack suggested pulling this information from vagrant-spk rather than confirming it is the same in both places. This change to the script is tested (as a stub in a separate script file) to correctly do that. I flipped the order the variables are populated, because TAG_NAME is closer to the output of the vagrant-spk --version command. I attempted to figure out how to get TAG_NAME to populate in one line, but was unsuccessful, because I am a bash rookie. (Maybe I can argue it's more readable as two lines anyways...)