### PR TITLE
Add env variable to skip changelog check

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -42,6 +42,11 @@ function get_release_name() {
 }
 
 function assert_changelog_present() {
+  if [[ "${SKIP_CHANGELOG_CHECK:-no}" == "yes" ]]; then
+    echo "Skipping changelog check due to SKIP_CHANGELOG_CHECK=yes in environment."
+    return
+  fi
+
   # Verify that the changelog has been updated.
   EXPECTED_CHANGELOG="### $TAG_NAME ($(date '+%Y-%m-%d'))"
   if [ "$(head -n 1 CHANGELOG.md)" != "$EXPECTED_CHANGELOG" ]; then


### PR DESCRIPTION
I am testing a GitHub Action in another branch, and there is no programmatic way to skip the changelog check, which I want to do for dry run tests prior to merging the action. I copied this from the option to skip the git clean check.