### PR TITLE
Bump golang toolchain version.

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-version=1.16.5
+version=1.16.6
 os=linux
 arch=amd64
 


### PR DESCRIPTION
1.16.6 includes some security fixes, though I don't think
any of them are likely to affect Sandstorm apps.