### PR TITLE
Update bitrotten comment in Vagrantfile template.

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -71,7 +71,7 @@ unless Vagrant::DEFAULT_SERVER_URL.frozen?
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Base on the Sandstorm snapshots of the official Debian 9 (stretch) box with vboxsf support.
+  # Base on the Sandstorm snapshots of the official Debian 10 (buster) box.
   config.vm.box = "debian/contrib-buster64"
   config.vm.post_up_message = "Your virtual server is running at http://local.sandstorm.io:6090."
 


### PR DESCRIPTION
The box itself was updated to buster a while back, but I noticed that
the comment still says stretch. I also got rid of the vboxfs bit; IIRC
there were separate images for these at one time, but they are no longer
needed.