### PR TITLE
Update bitrotten box comment

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -71,7 +71,7 @@ unless Vagrant::DEFAULT_SERVER_URL.frozen?
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Base on the Sandstorm snapshots of the official Debian 10 (buster) box.
+  # Base on a 64-bit Debian box with vboxsf support (ex. contrib-buster64, bullseye64)
   config.vm.box = "debian/contrib-buster64"
   config.vm.post_up_message = "Your virtual server is running at http://local.sandstorm.io:6090."
 


### PR DESCRIPTION
This is approaching bikeshedding, but I did want to get rid of the "Sandstorm snapshot of" bit...

I wanted to express here that Debian boxes should generally work with vagrant-spk if they have vboxsf support, which is not presently a guarantee depending which Debian box you go with (considering we're still targeting buster at the moment). The example text though should also help briefly express that as of bullseye, contrib- is no longer required.