### PR TITLE
Minor formatting tweak in Vagrantfile message

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -73,7 +73,7 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base on a 64-bit Debian box with vboxsf support (ex. contrib-buster64, bullseye64)
   config.vm.box = "debian/contrib-buster64"
-  config.vm.post_up_message = "Your virtual server is running at http://local.sandstorm.io:6090."
+  config.vm.post_up_message = "Your virtual server is running at: http://local.sandstorm.io:6090"
 
 
   if Vagrant.has_plugin?("vagrant-vbguest") then


### PR DESCRIPTION
This is a really trivial thing, but: my terminal's link detection seems
to want to include the period after the url in the url itself, which
means just trying to right click & open the link does not work
correctly. This patch gets around this by formatting the text in a way
that doesn't have the period at the end. I believe it still scans ok.