### PR TITLE
Update MySQL repo GPG key

### DIFF
--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 echo -e "deb http://repo.mysql.com/apt/debian/ buster mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
-wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql
+wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 apt-key add /tmp/RPM-GPG-KEY-mysql
 
 apt-get update

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 echo -e "deb http://repo.mysql.com/apt/debian/ buster mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
-wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql
+wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 apt-key add /tmp/RPM-GPG-KEY-mysql
 
 apt-get update


### PR DESCRIPTION
Fixes #321. It looks like Oracle has rotated their GPG keys starting with 8.0.28 (and likely patch releases for older supported versions). A note specifies the change in keys and their fingerprints here: https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/#repo-qg-apt-repo-manual-setup

I checked and the key at the new URL matches the KeyID described in the issue.