### PR TITLE
Fix remote-fs.target dependency cycle

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -142,7 +142,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # /opt/app and /host-dot-sandstorm are used by vagrant-spk
     override.vm.synced_folder "..", "/opt/app"
-    override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm"
+    override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm", mount_options: ["x-systemd.automount"]
     # /vagrant is not used by vagrant-spk; we need this line so it gets disabled; if we removed the
     # line, vagrant would automatically insert a synced folder in /vagrant, which is not what we want.
     override.vm.synced_folder "..", "/vagrant", disabled: true


### PR DESCRIPTION
Adding the automount option fixes a dependency cycle that can cause
Sandstorm to fail to start on boot for some development VMs.

The `host\x2ddot\x2dsandstorm.mount` is wanted by the `remote-fs.target`,
however it needs the `virtualbox-guest-utils.service` to mount
successfully.  The `virtualbox-guest-utils.service` can be made to run
before `remote-fs.target`, but I have never managed to make it be ready
for mounting Virtualbox Synced Folders at boot time.  It complains of
shared memory errors.  All of this causes the `remote-fs.target` to fail,
which causes `sandstorm.service` to fail to start at boot time.

This solution enables the automount option.  `/host-dot-sandstorm` is
instead no longer required for completion of the `remote-fs.target` and is
mounted on demand for `vagrant-spk`.  Everyone is happy.