### PR TITLE
Upgrade base box to Bullseye

### DIFF
--- a/stacks/lemp/launcher.sh
+++ b/stacks/lemp/launcher.sh
@@ -33,10 +33,10 @@ HOME=/etc/mysql /usr/sbin/mysqld --initialize
 
 # Spawn mysqld, php
 HOME=/etc/mysql /usr/sbin/mysqld --skip-grant-tables &
-/usr/sbin/php-fpm7.3 --nodaemonize --fpm-config /etc/php/7.3/fpm/php-fpm.conf &
+/usr/sbin/php-fpm7.4 --nodaemonize --fpm-config /etc/php/7.4/fpm/php-fpm.conf &
 # Wait until mysql and php have bound their sockets, indicating readiness
 wait_for mysql /var/run/mysqld/mysqld.sock
-wait_for php-fpm7.3 /var/run/php/php7.3-fpm.sock
+wait_for php-fpm7.4 /var/run/php/php7.4-fpm.sock
 
 # Start nginx.
 /usr/sbin/nginx -c /opt/app/.sandstorm/service-config/nginx.conf -g "daemon off;"

--- a/stacks/lemp/service-config/nginx.conf
+++ b/stacks/lemp/service-config/nginx.conf
@@ -50,7 +50,7 @@ http {
 			try_files $uri $uri/ =404;
 		}
 		location ~ \.php$ {
-			fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
+			fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
 			fastcgi_index index.php;
 			fastcgi_split_path_info ^(.+\.php)(/.+)$;
 			fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -7,38 +7,39 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo -e "deb http://repo.mysql.com/apt/debian/ buster mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+apt-get install -y gnupg
+echo -e "deb http://repo.mysql.com/apt/debian/ bullseye mysql-8.0\ndeb-src http://repo.mysql.com/apt/debian/ bullseye mysql-8.0" > /etc/apt/sources.list.d/mysql.list
 wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 apt-key add /tmp/RPM-GPG-KEY-mysql
 
 apt-get update
 apt-get install -y nginx php-fpm php-mysql php-cli php-curl git php-dev mysql-server
 service nginx stop
-service php7.3-fpm stop
+service php7.4-fpm stop
 service mysql stop
 systemctl disable nginx
-systemctl disable php7.3-fpm
+systemctl disable php7.4-fpm
 systemctl disable mysql
-# patch /etc/php/7.3/fpm/pool.d/www.conf to not change uid/gid to www-data
+# patch /etc/php/7.4/fpm/pool.d/www.conf to not change uid/gid to www-data
 sed --in-place='' \
         --expression='s/^listen.owner = www-data/;listen.owner = www-data/' \
         --expression='s/^listen.group = www-data/;listen.group = www-data/' \
         --expression='s/^user = www-data/;user = www-data/' \
         --expression='s/^group = www-data/;group = www-data/' \
-        /etc/php/7.3/fpm/pool.d/www.conf
-# patch /etc/php/7.3/fpm/php-fpm.conf to not have a pidfile
+        /etc/php/7.4/fpm/pool.d/www.conf
+# patch /etc/php/7.4/fpm/php-fpm.conf to not have a pidfile
 sed --in-place='' \
         --expression='s/^pid =/;pid =/' \
-        /etc/php/7.3/fpm/php-fpm.conf
-# patch /etc/php/7.3/fpm/php-fpm.conf to place the sock file in /var 
+        /etc/php/7.4/fpm/php-fpm.conf
+# patch /etc/php/7.4/fpm/php-fpm.conf to place the sock file in /var 
 sed --in-place='' \
-       --expression='s/^listen = \/run\/php\/php7.3-fpm.sock/listen = \/var\/run\/php\/php7.3-fpm.sock/' \
-        /etc/php/7.3/fpm/pool.d/www.conf
-# patch /etc/php/7.3/fpm/pool.d/www.conf to no clear environment variables
+       --expression='s/^listen = \/run\/php\/php7.4-fpm.sock/listen = \/var\/run\/php\/php7.4-fpm.sock/' \
+        /etc/php/7.4/fpm/pool.d/www.conf
+# patch /etc/php/7.4/fpm/pool.d/www.conf to no clear environment variables
 # so we can pass in SANDSTORM=1 to apps
 sed --in-place='' \
         --expression='s/^;clear_env = no/clear_env=no/' \
-        /etc/php/7.3/fpm/pool.d/www.conf
+        /etc/php/7.4/fpm/pool.d/www.conf
 # patch mysql conf to not change uid, and to use /var/tmp over /tmp
 # for secure-file-priv see https://github.com/sandstorm-io/vagrant-spk/issues/195
 sed --in-place='' \

--- a/stacks/lesp/launcher.sh
+++ b/stacks/lesp/launcher.sh
@@ -22,9 +22,9 @@ rm -rf /var/run
 mkdir -p /var/run/php
 
 # Spawn php
-/usr/sbin/php-fpm7.3 --nodaemonize --fpm-config /etc/php/7.3/fpm/php-fpm.conf &
+/usr/sbin/php-fpm7.4 --nodaemonize --fpm-config /etc/php/7.4/fpm/php-fpm.conf &
 # Wait until php has bound its socket, indicating readiness
-wait_for php-fpm7.3 /var/run/php/php7.3-fpm.sock
+wait_for php-fpm7.4 /var/run/php/php7.4-fpm.sock
 
 # Start nginx.
 /usr/sbin/nginx -c /opt/app/.sandstorm/service-config/nginx.conf -g "daemon off;"

--- a/stacks/lesp/service-config/nginx.conf
+++ b/stacks/lesp/service-config/nginx.conf
@@ -50,7 +50,7 @@ http {
 			try_files $uri $uri/ =404;
 		}
 		location ~ \.php$ {
-			fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
+			fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
 			fastcgi_index index.php;
 			fastcgi_split_path_info ^(.+\.php)(/.+)$;
 			fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/stacks/lesp/setup.sh
+++ b/stacks/lesp/setup.sh
@@ -9,26 +9,26 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y nginx php-fpm php-sqlite3 php-cli php-curl git php-dev
 service nginx stop
-service php7.3-fpm stop
+service php7.4-fpm stop
 systemctl disable nginx
-systemctl disable php7.3-fpm
-# patch /etc/php/7.3/fpm/pool.d/www.conf to not change uid/gid to www-data
+systemctl disable php7.4-fpm
+# patch /etc/php/7.4/fpm/pool.d/www.conf to not change uid/gid to www-data
 sed --in-place='' \
         --expression='s/^listen.owner = www-data/;listen.owner = www-data/' \
         --expression='s/^listen.group = www-data/;listen.group = www-data/' \
         --expression='s/^user = www-data/;user = www-data/' \
         --expression='s/^group = www-data/;group = www-data/' \
-        /etc/php/7.3/fpm/pool.d/www.conf
-# patch /etc/php/7.3/fpm/php-fpm.conf to not have a pidfile
+        /etc/php/7.4/fpm/pool.d/www.conf
+# patch /etc/php/7.4/fpm/php-fpm.conf to not have a pidfile
 sed --in-place='' \
         --expression='s/^pid =/;pid =/' \
-        /etc/php/7.3/fpm/php-fpm.conf
-# patch /etc/php/7.3/fpm/php-fpm.conf to place the sock file in /var
+        /etc/php/7.4/fpm/php-fpm.conf
+# patch /etc/php/7.4/fpm/php-fpm.conf to place the sock file in /var
 sed --in-place='' \
-       --expression='s/^listen = \/run\/php\/php7.3-fpm.sock/listen = \/var\/run\/php\/php7.3-fpm.sock/' \
-       /etc/php/7.3/fpm/pool.d/www.conf
-# patch /etc/php/7.3/fpm/pool.d/www.conf to no clear environment variables
+       --expression='s/^listen = \/run\/php\/php7.4-fpm.sock/listen = \/var\/run\/php\/php7.4-fpm.sock/' \
+       /etc/php/7.4/fpm/pool.d/www.conf
+# patch /etc/php/7.4/fpm/pool.d/www.conf to no clear environment variables
 # so we can pass in SANDSTORM=1 to apps
 sed --in-place='' \
         --expression='s/^;clear_env = no/clear_env=no/' \
-        /etc/php/7.3/fpm/pool.d/www.conf
+        /etc/php/7.4/fpm/pool.d/www.conf

--- a/stacks/node/setup.sh
+++ b/stacks/node/setup.sh
@@ -14,12 +14,12 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo "Installing the NodeSource Node.js 14.x repo..."
+echo "Installing the NodeSource Node.js 16.x repo..."
 
 apt-get update
 apt-get install -qq apt-transport-https
 
-curl -sL https://deb.nodesource.com/setup_14.x | bash -
+curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 # Actually install node
 apt-get install -qq nodejs git-core g++

--- a/stacks/node/setup.sh
+++ b/stacks/node/setup.sh
@@ -14,12 +14,12 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo "Installing the NodeSource Node.js 10.x repo..."
+echo "Installing the NodeSource Node.js 14.x repo..."
 
 apt-get update
 apt-get install -qq apt-transport-https
 
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
+curl -sL https://deb.nodesource.com/setup_14.x | bash -
 
 # Actually install node
 apt-get install -qq nodejs git-core g++

--- a/stacks/uwsgi/build.sh
+++ b/stacks/uwsgi/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
-VENV=/opt/app/env
+VENV=/opt/app-venv
 if [ ! -d $VENV ] ; then
+    sudo mkdir -p $VENV -m777
     virtualenv $VENV
 else
     echo "$VENV exists, moving on"

--- a/stacks/uwsgi/launcher.sh
+++ b/stacks/uwsgi/launcher.sh
@@ -43,7 +43,7 @@ wait_for mysql $MYSQL_SOCKET_FILE
 HOME=/var uwsgi \
         --socket $UWSGI_SOCKET_FILE \
         --plugin python3 \
-        --virtualenv /opt/app/env \
+        --virtualenv /opt/app-venv \
         --wsgi-file /opt/app/main.py &
 
 # Wait for uwsgi to bind its socket

--- a/stacks/uwsgi/launcher.sh
+++ b/stacks/uwsgi/launcher.sh
@@ -42,7 +42,7 @@ wait_for mysql $MYSQL_SOCKET_FILE
 # Spawn uwsgi
 HOME=/var uwsgi \
         --socket $UWSGI_SOCKET_FILE \
-        --plugin python \
+        --plugin python3 \
         --virtualenv /opt/app/env \
         --wsgi-file /opt/app/main.py &
 

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo -e "deb http://repo.mysql.com/apt/debian/ buster mysql-5.7\ndeb-src http://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+apt-get install -y gnupg
+echo -e "deb http://repo.mysql.com/apt/debian/ bullseye mysql-8.0\ndeb-src http://repo.mysql.com/apt/debian/ bullseye mysql-8.0" > /etc/apt/sources.list.d/mysql.list
 wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 apt-key add /tmp/RPM-GPG-KEY-mysql
 

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -13,7 +13,7 @@ wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 apt-key add /tmp/RPM-GPG-KEY-mysql
 
 apt-get update
-apt-get install -y nginx mysql-server libmysqlclient-dev uwsgi uwsgi-plugin-python build-essential python-dev python-virtualenv git
+apt-get install -y nginx mysql-server libmysqlclient-dev uwsgi uwsgi-plugin-python3 build-essential python3-dev python3-mysqldb python3-virtualenv git
 # patch mysql conf to not change uid, and to use /var/tmp over /tmp
 sed --in-place='' \
         --expression='s/^user\t\t= mysql/#user\t\t= mysql/' \

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -72,7 +72,7 @@ end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base on a 64-bit Debian box with vboxsf support (ex. contrib-buster64, bullseye64)
-  config.vm.box = "debian/contrib-buster64"
+  config.vm.box = "debian/bullseye64"
   config.vm.post_up_message = "Your virtual server is running at: http://local.sandstorm.io:6090"
 
 


### PR DESCRIPTION
I think we need to address #330 before we merge this, and I also am going to do some testing against our test packages yet. We still need good test packages for some stacks (#298), which is also arguably blocking #290.

This also fixes #255. Node 14 is a supported LTS releae, and node-capnp supports Node 14, so we'll bump that up to be relatively modern as well.