### PR TITLE
Install GnuPG in global-setup

### DIFF
--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get install -y gnupg
 echo -e "deb http://repo.mysql.com/apt/debian/ bullseye mysql-8.0\ndeb-src http://repo.mysql.com/apt/debian/ bullseye mysql-8.0" > /etc/apt/sources.list.d/mysql.list
 wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 apt-key add /tmp/RPM-GPG-KEY-mysql

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get install -y gnupg
 echo -e "deb http://repo.mysql.com/apt/debian/ bullseye mysql-8.0\ndeb-src http://repo.mysql.com/apt/debian/ bullseye mysql-8.0" > /etc/apt/sources.list.d/mysql.list
 wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 apt-key add /tmp/RPM-GPG-KEY-mysql

--- a/vagrant-spk
+++ b/vagrant-spk
@@ -198,8 +198,8 @@ apt-mark hold grub-pc
 apt-get update
 apt-get upgrade -y
 
-# Install curl that is needed below.
-apt-get install -y curl
+# Install curl needed below, and gnupg for package signing
+apt-get install -y curl gnupg
 
 # The following line copies stderr through stderr to cat without accidentally leaving it in the
 # output file. Be careful when changing. See: https://github.com/sandstorm-io/vagrant-spk/pull/159


### PR DESCRIPTION
I believe this should fix #337, we already install it in two common stacks anyways, and presumably it used to be installed in previous boxes.