### PR TITLE
Bump golang toolchain version

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-version=1.19.1
+version=1.19.2
 os=linux
 arch=amd64
 


### PR DESCRIPTION
This includes a few security fixes in the stdlib.