### PR TITLE
Use the latest golang when building a new package

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -5,16 +5,21 @@
 
 set -euo pipefail
 
-version=1.19.2
-os=linux
-arch=amd64
-
 # The version of golang in the debian repositories tends to be incredibly
 # out of date; let's get ourselves a newer version from upstream:
-curl -L https://golang.org/dl/go${version}.${os}-${arch}.tar.gz -o go.tar.gz
+if [ -e /opt/app/.sandstorm/go-version ]; then
+    # Get the same version we've used before
+    curl -L "https://go.dev/dl/$(cat '/opt/app/.sandstorm/go-version').linux-amd64.tar.gz" -o go.tar.gz
+else
+    # Get the newest version for a new project
+    curl -L "https://go.dev/dl/$(curl 'https://go.dev/VERSION?m=text').linux-amd64.tar.gz" -o go.tar.gz
+fi
 tar -C /usr/local -xzf go.tar.gz
 rm go.tar.gz
 echo 'export PATH=/usr/local/go/bin:$PATH' > /etc/profile.d/go.sh
+
+# Get the same version next time
+/usr/local/go/bin/go version | cut -d ' ' -f 3 > /opt/app/.sandstorm/go-version
 
 # Needed for fetching go libraries:
 apt-get install -y git


### PR DESCRIPTION
This change should end the need for regular updates to the Go stack: We will grab the latest version of Go, and store the version with the .sandstorm folder so we grab the same one on successive builds.

Note that I didn't change (or bother to check what it was) the working directory, and ended up using absolute paths, and I couldn't run "go" from PATH on line 22, so I continued that behavior. Ian, if you can make this PR more succinct or better, I am good with that, but this seems to work.

(Note, I am about to force-push to fix a tabs vs. spaces crime.)