### PR TITLE
Rotate log files by default

### DIFF
--- a/stacks/lemp/launcher.sh
+++ b/stacks/lemp/launcher.sh
@@ -27,6 +27,14 @@ rm -rf /var/tmp
 mkdir -p /var/tmp
 mkdir -p /var/run/mysqld
 
+# Rotate log files larger than 512K
+log_files="$(find /var/log -type f -name '*.log')"
+for f in $log_files; do
+    if [ $(du -b "$f" | awk '{print $1}') -ge $((512 * 1024)) ] ; then
+        mv $f $f.1
+    fi
+done
+
 # Ensure mysql tables created
 # HOME=/etc/mysql /usr/bin/mysql_install_db
 HOME=/etc/mysql /usr/sbin/mysqld --initialize

--- a/stacks/lesp/launcher.sh
+++ b/stacks/lesp/launcher.sh
@@ -21,6 +21,14 @@ mkdir -p /var/log/nginx
 rm -rf /var/run
 mkdir -p /var/run/php
 
+# Rotate log files larger than 512K
+log_files="$(find /var/log -type f -name '*.log')"
+for f in $log_files; do
+    if [ $(du -b "$f" | awk '{print $1}') -ge $((512 * 1024)) ] ; then
+        mv $f $f.1
+    fi
+done
+
 # Spawn php
 /usr/sbin/php-fpm7.4 --nodaemonize --fpm-config /etc/php/7.4/fpm/php-fpm.conf &
 # Wait until php has bound its socket, indicating readiness

--- a/stacks/static/launcher.sh
+++ b/stacks/static/launcher.sh
@@ -8,5 +8,13 @@ mkdir -p /var/log/nginx
 rm -rf /var/run
 mkdir -p /var/run
 
+# Rotate log files larger than 512K
+log_files="$(find /var/log -type f -name '*.log')"
+for f in $log_files; do
+    if [ $(du -b "$f" | awk '{print $1}') -ge $((512 * 1024)) ] ; then
+        mv $f $f.1
+    fi
+done
+
 # Start nginx.
 /usr/sbin/nginx -c /opt/app/.sandstorm/service-config/nginx.conf -g "daemon off;"

--- a/stacks/uwsgi/launcher.sh
+++ b/stacks/uwsgi/launcher.sh
@@ -26,6 +26,14 @@ rm -rf /var/tmp
 mkdir -p /var/tmp
 mkdir -p /var/run/mysqld
 
+# Rotate log files larger than 512K
+log_files="$(find /var/log -type f -name '*.log')"
+for f in $log_files; do
+    if [ $(du -b "$f" | awk '{print $1}') -ge $((512 * 1024)) ] ; then
+        mv $f $f.1
+    fi
+done
+
 UWSGI_SOCKET_FILE=/var/run/uwsgi.sock
 
 # Ensure mysql tables created


### PR DESCRIPTION
I added this bit to the launcher script for every stack that bothers to create /var/log (basically, any which include Nginx and/or MySQL). It's possible other stacks would benefit from it, but I didn't want to add unnecessary script to any stacks which don't definitively include behavior logging there.