### PR TITLE
Skip upgrading Guest Additions

### DIFF
--- a/vagrant-spk
+++ b/vagrant-spk
@@ -83,6 +83,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # needs to know how to compile kernel modules, etc., and so
     # we give it this hint about operating system type.
     config.vm.guest = "debian"
+    config.vbguest.auto_update = false
   end
 
   # We forward port 6090, the vagrant-spk web port, so that developers can


### PR DESCRIPTION
This has been a constant point for me where the VM has hung completely or taken 30+ minutes to complete since using Virtualbox 7.x with Bookworm. This week's updates to the latest Bookworm box and Virtualbox revision did not help. The Debian box uses Guest Additions 6.x, and it appears to work fine with 7.x anyways, so I want to just disable this plugin.