### PR TITLE
Replace Node install

### DIFF
--- a/stacks/node/setup.sh
+++ b/stacks/node/setup.sh
@@ -14,12 +14,11 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo "Installing the NodeSource Node.js 16.x repo..."
-
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 apt-get update
-apt-get install -qq apt-transport-https
-
-curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 # Actually install node
 apt-get install -qq nodejs git-core g++


### PR DESCRIPTION
Using the old curl | bash setup scripts now creates a 60-second delay where it complains and tells you to stop using it. This is the new style, which I used to package WBO. I used Node 18 for WBO, but selected Node 20 here, because it will be the current LTS in less than a week at this point, and I want to future-proof this PR for a release I intend to create... soon?