### PR TITLE
Initalize MySQL Once

### DIFF
--- a/stacks/lemp/launcher.sh
+++ b/stacks/lemp/launcher.sh
@@ -35,10 +35,9 @@ for f in $log_files; do
     fi
 done
 
-if [ ! -e /var/.db-initialized ]; then
+if [ ! -d /var/lib/mysql/mysql ]; then
     # Ensure mysql tables created
     HOME=/etc/mysql /usr/sbin/mysqld --initialize
-    touch /var/.db-initialized
 fi
 
 # Spawn mysqld, php

--- a/stacks/uwsgi/launcher.sh
+++ b/stacks/uwsgi/launcher.sh
@@ -36,10 +36,9 @@ done
 
 UWSGI_SOCKET_FILE=/var/run/uwsgi.sock
 
-if [ ! -e /var/.db-initialized ]; then
+if [ ! -d /var/lib/mysql/mysql ]; then
     # Ensure mysql tables created
     HOME=/etc/mysql /usr/sbin/mysqld --initialize
-    touch /var/.db-initialized
 fi
 
 # Spawn mysqld

--- a/stacks/uwsgi/launcher.sh
+++ b/stacks/uwsgi/launcher.sh
@@ -36,9 +36,11 @@ done
 
 UWSGI_SOCKET_FILE=/var/run/uwsgi.sock
 
-# Ensure mysql tables created
-# HOME=/etc/mysql /usr/bin/mysql_install_db
-HOME=/etc/mysql /usr/sbin/mysqld --initialize
+if [ ! -e /var/.db-initialized ]; then
+    # Ensure mysql tables created
+    HOME=/etc/mysql /usr/sbin/mysqld --initialize
+    touch /var/.db-initialized
+fi
 
 # Spawn mysqld
 HOME=/etc/mysql /usr/sbin/mysqld --skip-grant-tables &
@@ -46,6 +48,13 @@ HOME=/etc/mysql /usr/sbin/mysqld --skip-grant-tables &
 MYSQL_SOCKET_FILE=/var/run/mysqld/mysqld.sock
 # Wait for mysql to bind its socket
 wait_for mysql $MYSQL_SOCKET_FILE
+
+# # Uncomment this block if you need to preload a database for your app
+# if [ ! -e /var/.db-created ]; then
+#    mysql --user root -e 'CREATE DATABASE app'
+#    mysql --user root --database app < /opt/app/install.sql
+#    touch /var/.db-created
+# fi
 
 # Spawn uwsgi
 HOME=/var uwsgi \


### PR DESCRIPTION
So I believe this change is necessary to stabilize our lemp and uwsgi stacks, and fixes the roadblock I've been fighting on my own package. MySQL's documentation states --initialize should exit without changes if the directory isn't empty (aka, already initialized), but my guess is because we launch initialize without a password (or skip-grant-tables like our main process launch), it encounters an access error trying to verify the initialization is already done. I think the best choice is to just only initialize a grain once, it avoids some log cruft and is (probably) more efficient.

https://dev.mysql.com/doc/refman/8.0/en/data-directory-initialization.html#data-directory-initialization-procedure

I am also taking a behavior Ian used effectively in his grains and introducing it as a standard behavior, both for initializing and populating the database. Since the latter isn't always required, I'm including it in the template commented out.