### PR TITLE
Rename publisher in Windows installer

### DIFF
--- a/windows-support/windows-installer.iss
+++ b/windows-support/windows-installer.iss
@@ -3,7 +3,7 @@
 
 #define MyAppName "vagrant-spk"
 #include "state/version.iss"
-#define MyAppPublisher "Sandstorm Development Group, Inc."
+#define MyAppPublisher "The Sandstorm Project"
 #define MyAppURL "https://docs.sandstorm.io/"
 #define MyAppExeName "vagrant-spk.exe"
 


### PR DESCRIPTION
I'm not including this in 1.2, but leaving this PR out there in part as a reminder to do it next release. There is no Sandstorm Development Group, Inc. so we should rename this. It shows up in the legacy Control Panel primarily.