### PR TITLE
Go: Get latest version correctly

### DIFF
--- a/stacks/golang/setup.sh
+++ b/stacks/golang/setup.sh
@@ -12,7 +12,7 @@ if [ -e /opt/app/.sandstorm/go-version ]; then
     curl -L "https://go.dev/dl/$(cat '/opt/app/.sandstorm/go-version').linux-amd64.tar.gz" -o go.tar.gz
 else
     # Get the newest version for a new project
-    curl -L "https://go.dev/dl/$(curl 'https://go.dev/VERSION?m=text').linux-amd64.tar.gz" -o go.tar.gz
+    curl -L "https://go.dev/dl/$(curl 'https://go.dev/VERSION?m=text' | head -n 1).linux-amd64.tar.gz" -o go.tar.gz
 fi
 tar -C /usr/local -xzf go.tar.gz
 rm go.tar.gz


### PR DESCRIPTION
So our Go stack was broken, and I figured out why: https://go.dev/VERSION?m=text used to return the latest Go version (technically, the version the Go website uses, but I digress). Now it also includes a timestamp, and that broke this script.