### PR TITLE
Update MySQL GPG key

### DIFF
--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -8,8 +8,7 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 echo -e "deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.0\ndeb-src http://repo.mysql.com/apt/debian/ bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list
-wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2023
-apt-key add /tmp/RPM-GPG-KEY-mysql
+apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C
 
 apt-get update
 apt-get install -y nginx php-fpm php-mysql php-cli php-curl git php-dev mysql-server

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -8,8 +8,7 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 echo -e "deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.0\ndeb-src http://repo.mysql.com/apt/debian/ bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list
-wget -O /tmp/RPM-GPG-KEY-mysql https://repo.mysql.com/RPM-GPG-KEY-mysql-2023
-apt-key add /tmp/RPM-GPG-KEY-mysql
+apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C
 
 apt-get update
 apt-get install -y nginx mysql-server libmysqlclient-dev libssl-dev pkg-config uwsgi uwsgi-plugin-python3 build-essential python3-dev python3-mysqldb python3-virtualenv git


### PR DESCRIPTION
MySQL's key expired like a week ago, so you can't set up these stacks without updating the key. Apparently they didn't feel like uploading one to where the previous keys were *either*. But this is a working solution.