### PR TITLE
fix: note newer innodb_log_file_size

### DIFF
--- a/stacks/lemp/setup.sh
+++ b/stacks/lemp/setup.sh
@@ -50,11 +50,7 @@ sed --in-place='' \
 cat <<EOF > /etc/mysql/conf.d/sandstorm.cnf
 [mysqld]
 # Set the transaction log file to the minimum allowed size to save disk space.
-# MariaDB <= 10.8.2 (12 FEB 2022) => 1048576
-# MariaDB >= 10.8.3 (20 MAY 2022) => 4194304
-# MySQL <= 5.6 => 1048576
-# MySQL >= 5.7 (21 OCT 2015) => 4194304
-innodb_log_file_size = 1048576
+innodb_log_file_size = 4194304
 # Set the main data file to grow by 1MB at a time, rather than 8MB at a time.
 innodb_autoextend_increment = 1
 EOF

--- a/stacks/uwsgi/setup.sh
+++ b/stacks/uwsgi/setup.sh
@@ -22,11 +22,7 @@ sed --in-place='' \
 cat <<EOF > /etc/mysql/conf.d/sandstorm.cnf
 [mysqld]
 # Set the transaction log file to the minimum allowed size to save disk space.
-# MariaDB <= 10.8.2 => 1048576
-# MariaDB >= 10.8.3 (20 MAY 2022) => 4194304
-# MySQL <= 5.6 => 1048576
-# MySQL >= 5.7 (21 OCT 2015) => 4194304
-innodb_log_file_size = 1048576
+innodb_log_file_size = 4194304
 # Set the main data file to grow by 1MB at a time, rather than 8MB at a time.
 innodb_autoextend_increment = 1
 EOF


### PR DESCRIPTION
Newer versions of MySQL/MariaDB use a larger innodb_log_file_size setting and will refuse to run with the value present in this stack.